### PR TITLE
dotnet-svcutil: optimize the referenced wcf package version and add test.

### DIFF
--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeDom;
 using System.ServiceModel;
 using System.Threading.Tasks;
 using System.Linq;
-using System.Xml.Linq;
+using static Microsoft.Tools.ServiceModel.Svcutil.TargetFrameworkHelper;
 
 namespace Microsoft.Tools.ServiceModel.Svcutil
 {
@@ -32,7 +32,18 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             {
                 if (options.TargetFramework.IsDnx)
                 {
-                    if (TargetFrameworkHelper.NetCoreVersionReferenceTable.TryGetValue(options.TargetFramework.Version, out var referenceTable))
+                    bool findVersion = false;
+                    System.Collections.Generic.List<ProjectDependency> referenceTable = null;
+                    if(options.TargetFramework.Name != FrameworkInfo.Netstandard)
+                    {
+                        findVersion = NetCoreVersionReferenceTable.TryGetValue(options.TargetFramework.Version, out referenceTable);
+                    }
+                    else if (NetStandardToNetCoreVersionMap.Keys.Contains(options.TargetFramework.Version))
+                    {
+                        findVersion = NetCoreVersionReferenceTable.TryGetValue(NetCoreToWCFPackageReferenceVersionMap[NetStandardToNetCoreVersionMap[options.TargetFramework.Version]], out referenceTable);
+                    }
+
+                    if (findVersion)
                     {
                         string version = referenceTable.FirstOrDefault().Version;
                         string[] vers = version.Split('.');

--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/VisitorFixup.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/VisitorFixup.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         new SpecialIXmlSerializableRemapper(arrayOfXElementTypeHelper),
                         new EnsureAdditionalAssemblyReference(),
                         new CreateCallbackImpl((generator.Options & ServiceContractGenerationOptions.TaskBasedAsynchronousMethod) == ServiceContractGenerationOptions.TaskBasedAsynchronousMethod, generator),
-                        new AddAsyncOpenClose(options), // this one need to run after CreateCallbakImpl which provide name of VerifyCallbackEvents method
+                        new AddAsyncOpenClose(), // this one need to run after CreateCallbakImpl which provide name of VerifyCallbackEvents method
                         new TypeNameFixup()
                     };
 

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         var tfx = this.TargetFrameworks.FirstOrDefault(t => TargetFrameworkHelper.IsSupportedFramework(t, out dnxInfo) && dnxInfo.IsDnx);
                         if (!string.IsNullOrEmpty(tfx) && dnxInfo.Version.Major >= 6)
                         {
-                            _packageReferenceGroup.Add(new XAttribute("Condition", $"'$(TargetFramework)' != '{netfxInfo.FullName}'"));
+                            _packageReferenceGroup.Add(new XAttribute("Condition", $"!$(TargetFramework.StartsWith('net4'))"));
                         }
                     }
                 }
@@ -549,7 +549,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         {
                             if (this.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out netfxInfo) && !netfxInfo.IsDnx))
                             {
-                                this.ReferenceGroup.Add(new XElement("Reference", new XAttribute("Condition", $"'$(TargetFramework)' == '{netfxInfo.FullName}'"), new XAttribute("Include", dependency.AssemblyName), new XElement("HintPath", dependency.FullPath)));
+                                this.ReferenceGroup.Add(new XElement("Reference", new XAttribute("Condition", $"$(TargetFramework.StartsWith('net4'))"), new XAttribute("Include", dependency.AssemblyName), new XElement("HintPath", dependency.FullPath)));
                             }
                         }
                         else

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -134,12 +134,10 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         _packageReferenceGroup = refItems.FirstOrDefault().Parent;
                     }
 
-                    FrameworkInfo netfxInfo = null;
-                    FrameworkInfo dnxInfo = null;
-                    if (this.TargetFrameworks.Count() > 1 && this.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out netfxInfo) && !netfxInfo.IsDnx))
+                    if (this.TargetFrameworks.Count() > 1 && this.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo netfxInfo) && !netfxInfo.IsDnx))
                     {
-                        var tfx = this.TargetFrameworks.FirstOrDefault(t => TargetFrameworkHelper.IsSupportedFramework(t, out dnxInfo) && dnxInfo.IsDnx);
-                        if (!string.IsNullOrEmpty(tfx) && dnxInfo.Version.Major >= 6)
+                        Version ver = TargetFrameworkHelper.GetLowestNetCoreVersion(this.TargetFrameworks);
+                        if (ver != null && ver.Major >= 6)
                         {
                             _packageReferenceGroup.Add(new XAttribute("Condition", $"!$(TargetFramework.StartsWith('net4'))"));
                         }
@@ -541,13 +539,11 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         this.ProjectReferceGroup.Add(new XElement("ProjectReference", new XAttribute("Include", dependency.FullPath)));
                         break;
                     case ProjectDependencyType.Binary:
-                        FrameworkInfo netfxInfo = null;
-                        FrameworkInfo dnxInfo = null;
-                        string dnxStr = this.TargetFrameworks.FirstOrDefault(t => TargetFrameworkHelper.IsSupportedFramework(t, out dnxInfo) && dnxInfo.IsDnx);
+                        Version ver = TargetFrameworkHelper.GetLowestNetCoreVersion(this.TargetFrameworks);
                         if (this.TargetFrameworks.Count() > 1 && dependency.Name.Equals(TargetFrameworkHelper.FullFrameworkReferences.FirstOrDefault().Name)
-                            && !string.IsNullOrWhiteSpace(dnxStr) && dnxInfo.Version.Major >= 6)
+                            && ver != null && ver.Major >= 6)
                         {
-                            if (this.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out netfxInfo) && !netfxInfo.IsDnx))
+                            if (this.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo netfxInfo) && !netfxInfo.IsDnx))
                             {
                                 this.ReferenceGroup.Add(new XElement("Reference", new XAttribute("Condition", $"$(TargetFramework.StartsWith('net4'))"), new XAttribute("Include", dependency.AssemblyName), new XElement("HintPath", dependency.FullPath)));
                             }

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -101,11 +101,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             {new Version("8.0"), new List<ProjectDependency> {
                 ProjectDependency.FromPackage("System.ServiceModel.Http", "8.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Federation", "8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.UnixDomainSocket", "8.*"),
-                ProjectDependency.FromPackage("System.Web.Services.Description", "8.*")
+                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "8.*")
             } }
         };
 

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -15,12 +15,20 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
     {
         public static ReadOnlyDictionary<Version, Version> NetStandardToNetCoreVersionMap { get; } = new ReadOnlyDictionary<Version, Version>(new SortedDictionary<Version, Version>
          {
+            // Service Model requires netstandard1.3 so it is the minimum version that will work.
+             {new Version("1.3"), new Version("1.0") },
+             {new Version("1.4"), new Version("1.0") },
+             {new Version("1.5"), new Version("1.0") },
+             {new Version("1.6"), new Version("1.0") },
+             {new Version("1.6.1"), new Version("1.1") },
              {new Version("2.0"), new Version("2.0") },
              {new Version("2.1"), new Version("3.1") }
          });
 
         public static ReadOnlyDictionary<Version, Version> NetCoreToWCFPackageReferenceVersionMap { get; } = new ReadOnlyDictionary<Version, Version>(new SortedDictionary<Version, Version>
          {
+             {new Version("1.0"), new Version("2.0") },
+             {new Version("1.1"), new Version("2.0") },
              {new Version("2.0"), new Version("2.0") },
              {new Version("2.1"), new Version("2.0") },
              {new Version("2.2"), new Version("2.0") },

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -15,27 +15,18 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
     {
         public static ReadOnlyDictionary<Version, Version> NetStandardToNetCoreVersionMap { get; } = new ReadOnlyDictionary<Version, Version>(new SortedDictionary<Version, Version>
          {
-            // Service Model requires netstandard1.3 so it is the minimum version that will work.
-             {new Version("1.3"), new Version("1.0") },
-             {new Version("1.4"), new Version("1.0") },
-             {new Version("1.5"), new Version("1.0") },
-             {new Version("1.6"), new Version("1.0") },
-             {new Version("1.6.1"), new Version("1.1") },
-             {new Version("2.0"), new Version("5.1") },
-             {new Version("2.1"), new Version("5.1") }
+             {new Version("2.0"), new Version("2.0") },
+             {new Version("2.1"), new Version("3.1") }
          });
 
         public static ReadOnlyDictionary<Version, Version> NetCoreToWCFPackageReferenceVersionMap { get; } = new ReadOnlyDictionary<Version, Version>(new SortedDictionary<Version, Version>
          {
-             {new Version("1.0"), new Version("1.0") },
-             {new Version("1.1"), new Version("1.1") },
              {new Version("2.0"), new Version("2.0") },
-             {new Version("2.1"), new Version("2.1") },
-             {new Version("2.2"), new Version("2.1") },
-             {new Version("3.0"), new Version("2.1") },
-             {new Version("3.1"), new Version("3.1") },
-             {new Version("5.0"), new Version("5.0") },
-             {new Version("5.1"), new Version("5.1") },
+             {new Version("2.1"), new Version("2.0") },
+             {new Version("2.2"), new Version("2.0") },
+             {new Version("3.0"), new Version("2.0") },
+             {new Version("3.1"), new Version("2.0") },
+             {new Version("5.0"), new Version("2.0") },
              {new Version("6.0"), new Version("6.0") },
              {new Version("7.0"), new Version("6.0") },
              {new Version("8.0"), new Version("8.0") }
@@ -43,46 +34,8 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 
         internal static SortedDictionary<Version, List<ProjectDependency>> NetCoreVersionReferenceTable = new SortedDictionary<Version, List<ProjectDependency>>
         {
-            {new Version("1.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.0.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.1.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.1.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.0.*"),
-                ProjectDependency.FromPackage("System.Xml.XmlSerializer", "4.0.*"    ),
-            } },
-            {new Version("1.1"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.3.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.3.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.3.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.3.*"),
-                ProjectDependency.FromPackage("System.Xml.XmlSerializer", "4.3.*"    ),
-            } },
+           
             {new Version("2.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.4.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.4.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.4.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.4.*"),
-            } },
-            {new Version("2.1"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.6.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.6.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.6.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.6.*"),
-            } },
-            {new Version("3.1"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.7.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.7.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.7.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.7.*"),
-             } },
-            {new Version("5.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.8.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.8.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.8.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Federation", "4.8.*")
-            } },
-            {new Version("5.1"), new List<ProjectDependency> {
                 ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.10.*"  ),
                 ProjectDependency.FromPackage("System.ServiceModel.Http", "4.10.*"    ),
                 ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.10.*"  ),
@@ -129,31 +82,17 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         public static Version MinSupportedNetStandardVersion { get; } = NetStandardToNetCoreVersionMap.Keys.First();
         public static Version MinSupportedNetCoreAppVersion { get; } = NetCoreToWCFPackageReferenceVersionMap.Keys.First();
 
-        public static IEnumerable<ProjectDependency> GetWcfProjectReferences(string targetFramework)
+        public static IEnumerable<ProjectDependency> GetWcfProjectReferences(IEnumerable<string> targetFrameworks)
         {
             IEnumerable<ProjectDependency> dependencies = null;
-
-            if (IsSupportedFramework(targetFramework, out var frameworkInfo))
+            Version version = GetLowestNetCoreVersion(targetFrameworks);
+            if(version != null)
             {
-                if (frameworkInfo.IsDnx)
-                {
-                    if(frameworkInfo.Name == FrameworkInfo.Netstandard && TargetFrameworkHelper.NetStandardToNetCoreVersionMap.Keys.Contains(frameworkInfo.Version))
-                    {
-                        dependencies = NetCoreVersionReferenceTable[NetCoreToWCFPackageReferenceVersionMap[NetStandardToNetCoreVersionMap[frameworkInfo.Version]]];
-                    }
-                    else if(frameworkInfo.Name != FrameworkInfo.Netstandard && NetCoreToWCFPackageReferenceVersionMap.ContainsKey(frameworkInfo.Version))
-                    {
-                        dependencies = NetCoreVersionReferenceTable[NetCoreToWCFPackageReferenceVersionMap[frameworkInfo.Version]];
-                    }
-                    else
-                    {
-                        dependencies = NetCoreVersionReferenceTable.Last().Value;
-                    }
-                }
-                else
-                {
-                    dependencies = FullFrameworkReferences;
-                }
+                dependencies = NetCoreVersionReferenceTable[NetCoreToWCFPackageReferenceVersionMap[version]];
+            }
+            else
+            {
+                dependencies = FullFrameworkReferences;
             }
 
             return dependencies;
@@ -193,20 +132,36 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 
             foreach (string targetFramework in targetFrameworks)
             {
-                if (TargetFrameworkHelper.IsSupportedFramework(targetFramework, out var frameworkInfo) && frameworkInfo.IsDnx)
+                if (IsSupportedFramework(targetFramework, out var frameworkInfo) && frameworkInfo.IsDnx)
                 {
                     Version netCoreVersion;
 
                     if (frameworkInfo.IsKnownDnx)
                     {
-                        netCoreVersion = frameworkInfo.Name == FrameworkInfo.Netstandard ?
-                           TargetFrameworkHelper.NetStandardToNetCoreVersionMap[frameworkInfo.Version] :
-                           frameworkInfo.Version;
+
+                        if(frameworkInfo.Name == FrameworkInfo.Netstandard)
+                        {
+                            if(!NetStandardToNetCoreVersionMap.TryGetValue(frameworkInfo.Version, out netCoreVersion))
+                            {
+                                netCoreVersion = NetStandardToNetCoreVersionMap.LastOrDefault().Value;
+                            }
+                        }
+                        else
+                        {
+                            if (NetCoreToWCFPackageReferenceVersionMap.TryGetValue(frameworkInfo.Version, out Version version))
+                            {
+                                netCoreVersion = frameworkInfo.Version;
+                            }
+                            else
+                            {
+                                netCoreVersion = NetCoreToWCFPackageReferenceVersionMap.Keys.LastOrDefault();
+                            }
+                        }
                     }
                     else
                     {
                         // target framework is not known to the tool, use the latest known netcore version.
-                        netCoreVersion = TargetFrameworkHelper.NetCoreVersionReferenceTable.Keys.LastOrDefault();
+                        netCoreVersion = NetCoreToWCFPackageReferenceVersionMap.Keys.LastOrDefault();
                     }
 
                     if (targetVersion == null || targetVersion > netCoreVersion)

--- a/src/dotnet-svcutil/lib/src/Tool.cs
+++ b/src/dotnet-svcutil/lib/src/Tool.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         {
             try
             {
-                var dependencies = TargetFrameworkHelper.GetWcfProjectReferences(project.TargetFramework);
+                var dependencies = TargetFrameworkHelper.GetWcfProjectReferences(project.TargetFrameworks);
                 if (dependencies != null)
                 {
                     bool needSave = false;
@@ -289,8 +289,8 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     if (project.TargetFrameworks.Count() > 1 && project.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo fxInfo) && !fxInfo.IsDnx))
                     {
                         FrameworkInfo fxInfo = null;
-                        var tfx = project.TargetFrameworks.FirstOrDefault(t => TargetFrameworkHelper.IsSupportedFramework(t, out fxInfo) && fxInfo.IsDnx);
-                        if (!string.IsNullOrEmpty(tfx) && fxInfo.Version.Major >= 6)
+                        Version ver = TargetFrameworkHelper.GetLowestNetCoreVersion(project.TargetFrameworks);
+                        if (ver != null && ver.Major >= 6)
                         {
                             needSave |= project.AddDependency(TargetFrameworkHelper.FullFrameworkReferences.FirstOrDefault());
                         }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Auto/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Auto/Reference.cs
@@ -889,11 +889,6 @@ namespace Auto_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Auto/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Auto/Reference.cs
@@ -889,6 +889,13 @@ namespace Auto_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/CollectionArray/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/CollectionArray/Reference.cs
@@ -889,11 +889,6 @@ namespace CollectionArray_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/CollectionArray/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/CollectionArray/Reference.cs
@@ -889,6 +889,13 @@ namespace CollectionArray_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/DataContractSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/DataContractSerializer/Reference.cs
@@ -889,6 +889,13 @@ namespace DataContractSerializer_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/DataContractSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/DataContractSerializer/Reference.cs
@@ -889,11 +889,6 @@ namespace DataContractSerializer_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/EnableDataBinding/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/EnableDataBinding/Reference.cs
@@ -1122,11 +1122,6 @@ namespace EnableDataBinding_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/EnableDataBinding/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/EnableDataBinding/Reference.cs
@@ -1122,6 +1122,13 @@ namespace EnableDataBinding_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/ExcludeType/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/ExcludeType/Reference.cs
@@ -1036,6 +1036,13 @@ namespace ExcludeType_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/ExcludeType/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/ExcludeType/Reference.cs
@@ -1036,11 +1036,6 @@ namespace ExcludeType_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Internal/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Internal/Reference.cs
@@ -889,11 +889,6 @@ namespace Internal_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Internal/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Internal/Reference.cs
@@ -889,6 +889,13 @@ namespace Internal_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/MessageContract/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/MessageContract/Reference.cs
@@ -1239,6 +1239,13 @@ namespace MessageContract_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/MessageContract/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/MessageContract/Reference.cs
@@ -1239,11 +1239,6 @@ namespace MessageContract_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/NoStdLib/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/NoStdLib/Reference.cs
@@ -1063,11 +1063,6 @@ namespace NoStdLib_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/NoStdLib/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/NoStdLib/Reference.cs
@@ -1063,6 +1063,13 @@ namespace NoStdLib_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/None/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/None/Reference.cs
@@ -889,6 +889,13 @@ namespace None_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/None/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/None/Reference.cs
@@ -889,11 +889,6 @@ namespace None_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Sync/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Sync/Reference.cs
@@ -1020,6 +1020,13 @@ namespace Sync_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Sync/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Sync/Reference.cs
@@ -1020,11 +1020,6 @@ namespace Sync_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
@@ -1946,11 +1946,6 @@ namespace XmlSerializer_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
@@ -1946,6 +1946,13 @@ namespace XmlSerializer_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
@@ -2456,11 +2456,6 @@ namespace wrapped_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
@@ -2456,6 +2456,13 @@ namespace wrapped_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/Reference.cs
@@ -889,6 +889,13 @@ namespace array_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/array.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/array.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/Reference.cs
@@ -889,6 +889,13 @@ namespace arrayList_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/arrayList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/arrayList.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/Reference.cs
@@ -889,6 +889,13 @@ namespace collection_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/collection.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/collection.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace dictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/dictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/dictionary.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/Reference.cs
@@ -889,6 +889,13 @@ namespace hashTable_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/hashTable.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/hashTable.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace hybridDictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/hybridDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/hybridDictionary.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/Reference.cs
@@ -889,6 +889,13 @@ namespace linkedList_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/linkedList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/linkedList.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/Reference.cs
@@ -889,6 +889,13 @@ namespace list_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/list.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/list.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace listDictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/listDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/listDictionary.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/Reference.cs
@@ -889,6 +889,13 @@ namespace observableCollection_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/observableCollection.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/observableCollection.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace orderedDictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/orderedDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/orderedDictionary.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace sortedDictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/sortedDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/sortedDictionary.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/Reference.cs
@@ -889,6 +889,13 @@ namespace sortedList_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/sortedList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/sortedList.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/Reference.cs
@@ -889,6 +889,13 @@ namespace sortedListNonGeneric_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/sortedListNonGeneric.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/sortedListNonGeneric.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/ContractMemberNamedSystem/ContractMemberNamedSystem/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/ContractMemberNamedSystem/ContractMemberNamedSystem/Reference.cs
@@ -164,6 +164,13 @@ namespace ContractMemberNamedSystem_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/ContractTypeNamedReservedKeyword/ContractTypeNamedReservedKeyword/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/ContractTypeNamedReservedKeyword/ContractTypeNamedReservedKeyword/Reference.cs
@@ -265,6 +265,13 @@ namespace ContractTypeNamedReservedKeyword_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/DuplexCallback/Duplex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/DuplexCallback/Duplex/Reference.cs
@@ -88,6 +88,13 @@ namespace Duplex_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.tcp_nosecurity_callback_IWcfDuplexService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
@@ -616,8 +616,8 @@ namespace Saml2IssuedToken_mex_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.TestFaultsResponse> TestFaultsAsync(Saml2IssuedToken_mex_NS.TestFaultsRequest request);
         
@@ -2646,6 +2646,13 @@ namespace Saml2IssuedToken_mex_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
@@ -616,8 +616,8 @@ namespace Saml2IssuedToken_mex_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.TestFaultsResponse> TestFaultsAsync(Saml2IssuedToken_mex_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace Saml2IssuedToken_mex_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(Saml2IssuedToken_mex_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2640,6 +2644,11 @@ namespace Saml2IssuedToken_mex_NS
         {
             Saml2IssuedToken_mex_NS.GetRequestHttpHeadersRequest inValue = new Saml2IssuedToken_mex_NS.GetRequestHttpHeadersRequest();
             return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
@@ -889,10 +889,12 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
@@ -889,6 +889,11 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
@@ -889,11 +889,6 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/dotnet-svcutil.params.json
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/dotnet-svcutil.params.json
@@ -9,7 +9,7 @@
       "*, ServiceReference"
     ],
     "outputFile": "Reference.cs",
-    "targetFramework": "N.N",
+    "targetFramework": "net46",
     "typeReuseMode": "All"
   }
 }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/Reference.cs
@@ -126,6 +126,13 @@ namespace mexParam_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Service1_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/mexParam.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/mexParam.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/Reference.cs
@@ -126,6 +126,13 @@ namespace noQuery_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Service1_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/noQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/noQuery.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/Reference.cs
@@ -126,6 +126,13 @@ namespace singleWsdlQuery_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Service1_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/singleWsdlQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/singleWsdlQuery.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/Reference.cs
@@ -126,6 +126,13 @@ namespace wsdlQuery_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Service1_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/wsdlQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/wsdlQuery.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net48/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net48/ServiceReference/Reference.cs
@@ -148,10 +148,12 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/ServiceReference/Reference.cs
@@ -148,10 +148,12 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/ServiceReference/Reference.cs
@@ -148,6 +148,11 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/ServiceReference/Reference.cs
@@ -148,11 +148,6 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/ServiceReference/dotnet-svcutil.params.json
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/ServiceReference/dotnet-svcutil.params.json
@@ -1,0 +1,15 @@
+{
+  "providerId": "Microsoft.Tools.ServiceModel.Svcutil",
+  "version": "99.99.99",
+  "options": {
+    "inputs": [
+      "$testCasesPath$/wsdl/Simple.wsdl"
+    ],
+    "namespaceMappings": [
+      "*, ServiceReference"
+    ],
+    "outputFile": "Reference.cs",
+    "targetFramework": "N.N",
+    "typeReuseMode": "All"
+  }
+}

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/net50.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net50/net50.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>N.N</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/ServiceReference/Reference.cs
@@ -148,6 +148,13 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/ServiceReference/Reference.cs
@@ -148,7 +148,7 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        #if NETFRAMEWORK
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
@@ -13,7 +13,7 @@
     <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
   <ItemGroup>
-    <Reference Condition="'$(TargetFramework)' == 'net48'" Include="System.ServiceModel">
+    <Reference Condition="$(TargetFramework.StartsWith('net4'))" Include="System.ServiceModel">
       <HintPath>System.ServiceModel</HintPath>
     </Reference>
   </ItemGroup>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/ServiceReference/Reference.cs
@@ -148,10 +148,12 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/ServiceReference/Reference.cs
@@ -148,6 +148,11 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/Reference.cs
@@ -126,6 +126,13 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAll/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAll/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocAll_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAllRelative/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAllRelative/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocAllRelative_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullAndWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullAndWildcard/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocFullAndWildcard_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullPath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullPath/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocFullPath_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativeAndWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativeAndWildcard/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocRelativeAndWildcard_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativePath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativePath/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocRelativePath_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlRelXsdWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlRelXsdWildcard/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocWsdlRelXsdWildcard_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcard/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocWsdlWildcard_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcardRelative/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcardRelative/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocWsdlWildcardRelative_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlXsdWildcardRelative/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlXsdWildcardRelative/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocWsdlXsdWildcardRelative_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/urlNamespace/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/urlNamespace/Reference.cs
@@ -899,6 +899,13 @@ public partial class WcfProjectNServiceClient : System.ServiceModel.ClientBase<I
         return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
     }
     
+    #if !NET6_0_OR_GREATER
+    public virtual System.Threading.Tasks.Task CloseAsync()
+    {
+        return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+    }
+    #endif
+    
     private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
     {
         if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/wildcardNamespace/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/wildcardNamespace/Reference.cs
@@ -889,6 +889,13 @@ namespace TestNamespace
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/Reference.cs
@@ -148,6 +148,13 @@ namespace net90_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/net90.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/net90.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/Reference.cs
@@ -148,6 +148,13 @@ namespace tfm100_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/tfm100.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/tfm100.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/Reference.cs
@@ -148,11 +148,6 @@ namespace tfm20_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/Reference.cs
@@ -148,6 +148,13 @@ namespace tfm20_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/tfm20.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/tfm20.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/Reference.cs
@@ -148,11 +148,6 @@ namespace tfm45_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/Reference.cs
@@ -148,6 +148,13 @@ namespace tfm45_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/tfm45.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/tfm45.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/Reference.cs
@@ -148,6 +148,13 @@ namespace tfmDefault_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/tfmDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/tfmDefault.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping/Reference.cs
@@ -88,6 +88,13 @@ namespace UpdateNetPipeServiceRefBootstrapping
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.NetNamedPipeBinding_IStreamedService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault/Reference.cs
@@ -88,6 +88,13 @@ namespace UpdateNetPipeServiceRefDefault
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.NetNamedPipeBinding_IStreamedService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefBootstrapping
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefBootstrapping
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefDefault
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefDefault
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateRefLevels.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateRefLevels.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevels/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevels/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevels
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevels/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevels/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevels
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateRefLevelsFull.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateRefLevelsFull.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevelsFull/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevelsFull/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevelsFull
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevelsFull/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevelsFull/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevelsFull
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptionsDefault
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptionsDefault
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptionsExtraOptions
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptionsExtraOptions
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptionsExtraOptionsWarn
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptionsExtraOptionsWarn
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptionsFilePath
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptionsFilePath
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptionsFullPath
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptionsFullPath
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptionsRef
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptionsRef
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptionsRef2
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptionsRef2
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions Folder With Spaces/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions Folder With Spaces/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions Folder With Spaces/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions Folder With Spaces/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions_Folder_With_Spaces.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions_Folder_With_Spaces.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions Folder With Spaces Full/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions Folder With Spaces Full/Reference.cs
@@ -148,6 +148,13 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces_Full
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions Folder With Spaces Full/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions Folder With Spaces Full/Reference.cs
@@ -148,11 +148,6 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces_Full
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        public virtual System.Threading.Tasks.Task CloseAsync()
-        {
-            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
-        }
-        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions_Folder_With_Spaces_Full.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions_Folder_With_Spaces_Full.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/CSServiceReference.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/CSServiceReference.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/Connected Services/CSServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/Connected Services/CSServiceReference/Reference.cs
@@ -148,6 +148,13 @@ namespace ServiceReference1
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/CSServiceReferenceRoundtrip.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/CSServiceReferenceRoundtrip.csproj
@@ -14,8 +14,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/Connected Services/CSServiceReferenceRoundtrip/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/Connected Services/CSServiceReferenceRoundtrip/Reference.cs
@@ -148,6 +148,13 @@ namespace CSServiceReferenceRoundtrip_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
@@ -616,8 +616,8 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(BasicHttpsTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -2646,6 +2646,13 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
@@ -616,8 +616,8 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(BasicHttpsTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2640,6 +2644,11 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
         {
             BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest();
             return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
@@ -2647,6 +2647,13 @@ namespace BasicHttp_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Text_IWcfService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
@@ -616,8 +616,8 @@ namespace BasicHttp_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttp_NS.TestFaultsResponse> TestFaultsAsync(BasicHttp_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace BasicHttp_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttp_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(BasicHttp_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2640,6 +2644,11 @@ namespace BasicHttp_NS
         {
             BasicHttp_NS.GetRequestHttpHeadersRequest inValue = new BasicHttp_NS.GetRequestHttpHeadersRequest();
             return ((BasicHttp_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitDualNs/Reference.cs
@@ -779,6 +779,13 @@ namespace BasicHttpDocLitDualNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorDocLit))
@@ -1071,6 +1078,13 @@ namespace BasicHttpDocLitDualNs_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitSingleNs/Reference.cs
@@ -779,6 +779,13 @@ namespace BasicHttpDocLitSingleNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorDocLit))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncDualNs/Reference.cs
@@ -259,6 +259,13 @@ namespace BasicHttpRpcEncDualNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorRpcEnc))
@@ -378,6 +385,13 @@ namespace BasicHttpRpcEncDualNs_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncSingleNs/Reference.cs
@@ -259,6 +259,13 @@ namespace BasicHttpRpcEncSingleNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorRpcEnc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitDualNs/Reference.cs
@@ -256,6 +256,13 @@ namespace BasicHttpRpcLitDualNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorRpcLit))
@@ -375,6 +382,13 @@ namespace BasicHttpRpcLitDualNs_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitSingleNs/Reference.cs
@@ -256,6 +256,13 @@ namespace BasicHttpRpcLitSingleNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorRpcLit))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpSoap/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpSoap/Reference.cs
@@ -213,6 +213,13 @@ namespace BasicHttpSoap_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_IWcfSoapService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp_4_4_0/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp_4_4_0/Reference.cs
@@ -256,6 +256,13 @@ namespace BasicHttp_4_4_0_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_IWcfService_4_4_0))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
@@ -2647,6 +2647,13 @@ namespace BasicHttps_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Text_IWcfService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
@@ -616,8 +616,8 @@ namespace BasicHttps_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttps_NS.TestFaultsResponse> TestFaultsAsync(BasicHttps_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace BasicHttps_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttps_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(BasicHttps_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2640,6 +2644,11 @@ namespace BasicHttps_NS
         {
             BasicHttps_NS.GetRequestHttpHeadersRequest inValue = new BasicHttps_NS.GetRequestHttpHeadersRequest();
             return ((BasicHttps_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttp_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttp_NS.TestFaultsResponse> TestFaultsAsync(NetHttp_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace NetHttp_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttp_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(NetHttp_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2640,6 +2644,11 @@ namespace NetHttp_NS
         {
             NetHttp_NS.GetRequestHttpHeadersRequest inValue = new NetHttp_NS.GetRequestHttpHeadersRequest();
             return ((NetHttp_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttp_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttp_NS.TestFaultsResponse> TestFaultsAsync(NetHttp_NS.TestFaultsRequest request);
         
@@ -2646,6 +2646,13 @@ namespace NetHttp_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttpWebSockets_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpWebSockets_NS.TestFaultsResponse> TestFaultsAsync(NetHttpWebSockets_NS.TestFaultsRequest request);
         
@@ -2653,6 +2653,13 @@ namespace NetHttpWebSockets_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttpWebSockets_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpWebSockets_NS.TestFaultsResponse> TestFaultsAsync(NetHttpWebSockets_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace NetHttpWebSockets_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpWebSockets_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(NetHttpWebSockets_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2647,6 +2651,11 @@ namespace NetHttpWebSockets_NS
         {
             NetHttpWebSockets_NS.GetRequestHttpHeadersRequest inValue = new NetHttpWebSockets_NS.GetRequestHttpHeadersRequest();
             return ((NetHttpWebSockets_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttps_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttps_NS.TestFaultsResponse> TestFaultsAsync(NetHttps_NS.TestFaultsRequest request);
         
@@ -2646,6 +2646,13 @@ namespace NetHttps_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttps_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttps_NS.TestFaultsResponse> TestFaultsAsync(NetHttps_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace NetHttps_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttps_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(NetHttps_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2640,6 +2644,11 @@ namespace NetHttps_NS
         {
             NetHttps_NS.GetRequestHttpHeadersRequest inValue = new NetHttps_NS.GetRequestHttpHeadersRequest();
             return ((NetHttps_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttpsWebSockets_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpsWebSockets_NS.TestFaultsResponse> TestFaultsAsync(NetHttpsWebSockets_NS.TestFaultsRequest request);
         
@@ -2653,6 +2653,13 @@ namespace NetHttpsWebSockets_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttpsWebSockets_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpsWebSockets_NS.TestFaultsResponse> TestFaultsAsync(NetHttpsWebSockets_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace NetHttpsWebSockets_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpsWebSockets_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(NetHttpsWebSockets_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2647,6 +2651,11 @@ namespace NetHttpsWebSockets_NS
         {
             NetHttpsWebSockets_NS.GetRequestHttpHeadersRequest inValue = new NetHttpsWebSockets_NS.GetRequestHttpHeadersRequest();
             return ((NetHttpsWebSockets_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
@@ -616,8 +616,8 @@ namespace TcpTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(TcpTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -2653,6 +2653,13 @@ namespace TcpTransSecMessCredsUserName_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
@@ -616,8 +616,8 @@ namespace TcpTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(TcpTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace TcpTransSecMessCredsUserName_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2647,6 +2651,11 @@ namespace TcpTransSecMessCredsUserName_NS
         {
             TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest inValue = new TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest();
             return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeReliableSessionSvc/ReliableSessionService/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeReliableSessionSvc/ReliableSessionService/Reference.cs
@@ -81,6 +81,13 @@ namespace ReliableSessionService_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.NetHttpOrdered_WSReliableMessaging11_IWcfReliableService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
@@ -616,8 +616,8 @@ namespace HttpsTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(HttpsTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace HttpsTransSecMessCredsUserName_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2640,6 +2644,11 @@ namespace HttpsTransSecMessCredsUserName_NS
         {
             HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest inValue = new HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest();
             return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+        }
+        
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
@@ -616,8 +616,8 @@ namespace HttpsTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(HttpsTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -2646,6 +2646,13 @@ namespace HttpsTransSecMessCredsUserName_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/TestCases/MultiTargetCloseAsyncGeneration/net50/Program.cs
+++ b/src/dotnet-svcutil/lib/tests/TestCases/MultiTargetCloseAsyncGeneration/net50/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace net50
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/dotnet-svcutil/lib/tests/TestCases/MultiTargetCloseAsyncGeneration/net50/net50.csproj
+++ b/src/dotnet-svcutil/lib/tests/TestCases/MultiTargetCloseAsyncGeneration/net50/net50.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/dotnet-svcutil/lib/tests/src/E2ETests.cs
+++ b/src/dotnet-svcutil/lib/tests/src/E2ETests.cs
@@ -120,7 +120,7 @@ namespace SvcutilTest
             InitializeE2E(testCaseName);
 
             var uri = Path.Combine(g_TestCasesDir, "wsdl", "WcfProjectNService", "tempuri.org.wsdl");
-            var options = $"{uri} {optionModifier} -nl -tf netcoreapp1.0";
+            var options = $"{uri} {optionModifier} -nl -tf net8.0";
             this_TestCaseName = testCaseName;
             TestSvcutil(AppendCommonOptions(options));
         }

--- a/src/dotnet-svcutil/lib/tests/src/GlobalToolTests.cs
+++ b/src/dotnet-svcutil/lib/tests/src/GlobalToolTests.cs
@@ -101,18 +101,18 @@ namespace SvcutilTest
 
             var uri = Path.Combine(g_TestCasesDir, "wsdl", "WcfProjectNService", "tempuri.org.wsdl");
             var outDir = Path.Combine(this_TestCaseOutputDir, "ServiceReference");
-            var options = $"{uri} -nl -d {outDir} -tf netcoreapp1.0";
+            var options = $"{uri} -nl -d {outDir} -tf net8.0";
             
             TestGlobalSvcutil(options, expectSuccess: true);
         }
 
         [Trait("Category", "BVT")]
         [Theory]
-        [InlineData("net48")] //System.ServiceModel get referened and CloseAsync() is generated
-        [InlineData("net50")] //WCF package older than V4.10 get referened and CloseAsync() is generated
-        [InlineData("netstd20")] //WCF package of V4.10.* get referened and CloseAsync() is not generated
-        [InlineData("net60")] //WCF package newer than V4.10 get referened and CloseAsync() is not generated
-        [InlineData("net60net48")] //WCF package newer than V4.10 and System.ServiceModel.dll are referenced conditionally by target and CloseAsync() be generarted with conditional compilation mark
+        [InlineData("net48")] //System.ServiceModel get referenced and CloseAsync() is generated
+        [InlineData("net50")] //WCF package V4.10 get referenced and CloseAsync() is not generated
+        [InlineData("netstd20")] //WCF package V4.10 get referenced and CloseAsync() is not generated
+        [InlineData("net60")] //WCF package V6.* get referenced and CloseAsync() is not generated
+        [InlineData("net60net48")] //WCF package V6.* and System.ServiceModel.dll are conditionally referenced base on TFM and CloseAsync() is generarted with compilation marker
         public async Task MultiTargetCloseAsyncGeneration(string testCaseName)
         {
             this_TestCaseName = "MultiTargetCloseAsyncGeneration";

--- a/src/dotnet-svcutil/lib/tests/src/GlobalToolTests.cs
+++ b/src/dotnet-svcutil/lib/tests/src/GlobalToolTests.cs
@@ -101,7 +101,7 @@ namespace SvcutilTest
 
             var uri = Path.Combine(g_TestCasesDir, "wsdl", "WcfProjectNService", "tempuri.org.wsdl");
             var outDir = Path.Combine(this_TestCaseOutputDir, "ServiceReference");
-            var options = $"{uri} -nl -d {outDir} -tf net8.0";
+            var options = $"{uri} -nl -d {outDir}";
             
             TestGlobalSvcutil(options, expectSuccess: true);
         }
@@ -109,8 +109,8 @@ namespace SvcutilTest
         [Trait("Category", "BVT")]
         [Theory]
         [InlineData("net48")] //System.ServiceModel get referenced and CloseAsync() is generated
-        [InlineData("net50")] //WCF package V4.10 get referenced and CloseAsync() is not generated
-        [InlineData("netstd20")] //WCF package V4.10 get referenced and CloseAsync() is not generated
+        [InlineData("net50")] //WCF package V4.10 get referenced and CloseAsync() is generated
+        [InlineData("netstd20")] //WCF package V4.10 get referenced and CloseAsync() is generated
         [InlineData("net60")] //WCF package V6.* get referenced and CloseAsync() is not generated
         [InlineData("net60net48")] //WCF package V6.* and System.ServiceModel.dll are conditionally referenced base on TFM and CloseAsync() is generarted with compilation marker
         public async Task MultiTargetCloseAsyncGeneration(string testCaseName)

--- a/src/dotnet-svcutil/lib/tests/src/GlobalToolTests.cs
+++ b/src/dotnet-svcutil/lib/tests/src/GlobalToolTests.cs
@@ -109,7 +109,8 @@ namespace SvcutilTest
         [Trait("Category", "BVT")]
         [Theory]
         [InlineData("net48")] //System.ServiceModel get referened and CloseAsync() is generated
-        [InlineData("netstd20")] //WCF package older than V4.10 get referened and CloseAsync() is generated
+        [InlineData("net50")] //WCF package older than V4.10 get referened and CloseAsync() is generated
+        [InlineData("netstd20")] //WCF package of V4.10.* get referened and CloseAsync() is not generated
         [InlineData("net60")] //WCF package newer than V4.10 get referened and CloseAsync() is not generated
         [InlineData("net60net48")] //WCF package newer than V4.10 and System.ServiceModel.dll are referenced conditionally by target and CloseAsync() be generarted with conditional compilation mark
         public async Task MultiTargetCloseAsyncGeneration(string testCaseName)


### PR DESCRIPTION
Addresses #5499. 

Description:
1. Correctly resolve netstandard2.0 if the TFM moniker string was passed from VS (WCF CS Tool)
2. Create clear table mapping between .NET target version and wcf package version, for the various wcf releases which support netstandard2.0, keep the latest version 4.10.* only; update CloseAsync() generation logic to generate it for TFM less than 6.0, and update test baselines
3. Add only the common wcf references for version 8.0 packages, update corresponding test baselines
4. Improve wcf assembly reference condition for .NET framework target (use $(TargetFramework.StartsWith('net4') instead of getting the first .NET target and check for equality, this will fix bug when there're multiple .NET framework 4.x targets)
