### PR TITLE
Add IMergeEnabledMessageProperty to S.S.Primitives

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -1574,6 +1574,10 @@ namespace System.ServiceModel.Channels
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default; }
         public void Remove(System.ServiceModel.Channels.MessageHeaderInfo headerInfo) { }
     }
+    internal interface IMergeEnabledMessageProperty
+    {
+        bool TryMergeWithProperty(object propertyToMerge);
+    }
 }
 namespace System.ServiceModel.Description
 {


### PR DESCRIPTION
Addresses https://github.com/dotnet/wcf/issues/5202#issuecomment-2048100444:

class `HttpRequestMessageProperty `implements `IMessageProperty `and `IMergeEnabledMessageProperty`, `IMergeEnabledMessageProperty `does not exist in `System.ServiceModel.Primitives.ref.csproj`.