### PR TITLE
dotnet-svcutil: update metadataSourceFiles for URL input to correctly compute hash for caching ServiceDescriptor

### DIFF
--- a/src/dotnet-svcutil/lib/src/Metadata/MetadataDocumentLoader.cs
+++ b/src/dotnet-svcutil/lib/src/Metadata/MetadataDocumentLoader.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil.Metadata
             else
             {
                 _resolveExternalDocs = true;
+                this.metadataSourceFiles.Add(metadataUri);
                 this.MetadataSourceUrl = metadataUri;
             }
         }


### PR DESCRIPTION
This update addresses a bug in the WCF Connected Services Tool where switching between different service URL addresses would consistently cache the initial input, resulting in inaccurate display within the Services tree view.