### PR TITLE
[release/6.1] Update Linux image pool.

### DIFF
--- a/eng/SendToHelix.proj
+++ b/eng/SendToHelix.proj
@@ -30,17 +30,18 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestJob)' == 'Windows' AND '$(RunAsInternal)'" >
-    <HelixTargetQueue Include="windows.11.amd64.client" />
-    <HelixTargetQueue Include="(Debian.11.Amd64)ubuntu.2004.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64" />
-    <HelixTargetQueue Include="RedHat.7.Amd64" />
+    <HelixTargetQueue Include="windows.11.amd64.client" />    
+    <HelixTargetQueue Include="(Debian.11.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64" />
+    <HelixTargetQueue Include="(Mariner.2.0.Amd64.Open)Ubuntu.2204.Amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TestJob)' == 'Linux'" >
-    <HelixTargetQueue Include="Centos.7.Amd64.Open" />
-    <HelixTargetQueue Include="(Debian.11.Amd64.Open)ubuntu.2004.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64" />
-    <HelixTargetQueue Include="RedHat.7.Amd64.Open" />
+  <ItemGroup Condition="'$(TestJob)' == 'Linux'" >   
     <HelixTargetQueue Include="SLES.15.Amd64.Open" />
-    <HelixTargetQueue Include="Ubuntu.2004.Amd64.Open" />
+    <HelixTargetQueue Include="(Fedora.38.Amd64.Open)ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-helix" />
+    <HelixTargetQueue Include="Ubuntu.2204.Amd64.Open" />
+    <HelixTargetQueue Include="(Debian.11.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64" />
+    <HelixTargetQueue Include="(Mariner.2.0.Amd64.Open)Ubuntu.2204.Amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64" />
+    <HelixTargetQueue Include="(openSUSE.15.2.Amd64.Open)Ubuntu.2204.Amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:opensuse-15.2-helix-amd64" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestJob)' == 'MacOS'" >

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
@@ -28,7 +28,7 @@ namespace Infrastructure.Common
 
         private static List<Tuple<string, OSID>> _runtimeToOSID = new List<Tuple<string, OSID>>
         {
-            new Tuple<string, OSID>("centos", OSID.CentOS),
+            new Tuple<string, OSID>("Mariner", OSID.Mariner),
             new Tuple<string, OSID>("debian", OSID.Debian),
             new Tuple<string, OSID>("fedora", OSID.Fedora),
             new Tuple<string, OSID>("sles", OSID.SLES),

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
@@ -36,7 +36,7 @@ namespace Infrastructure.Common
              Windows_Server_2008 | Windows_Server_2008_R2 | Windows_Server_2012 | Windows_Server_2012_R2 | Windows_Server_2016 |
              WindowsPhone | Windows_Nano,
 
-        CentOS =                 0x00000800,
+        Mariner =                0x00000800,
         Debian =                 0x00001000,
         Fedora =                 0x00002000,
         SLES =                   0x00004000,
@@ -47,7 +47,7 @@ namespace Infrastructure.Common
 
         // 'Any' combinations must explicitly name only known flags so "G" formatting
         // can be used to show a comma separated list of the bitmask.
-        AnyUnix = CentOS | Debian | Fedora | OpenSUSE | OSX | RHEL | Ubuntu,
+        AnyUnix = Mariner | Debian | Fedora | OpenSUSE | OSX | RHEL | Ubuntu,
 
         Any = AnyUnix | AnyWindows
     }


### PR DESCRIPTION
Recent checks on Linux fails due to Centos.7 was set for removal. 
Addressing this by referring to PR #5369. 