### PR TITLE
Fix UnixDomainSocketBinding default security issue on Windows.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/UDS/UDSBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/UDS/UDSBindingTests.cs
@@ -75,13 +75,9 @@ public partial class Binding_UDSBindingTests : ConditionalWcfTest
                 System.ServiceModel.UnixDomainSocketBinding binding = new UnixDomainSocketBinding(System.ServiceModel.UnixDomainSocketSecurityMode.Transport);
                 binding.Security.Transport.ClientCredentialType = System.ServiceModel.UnixDomainSocketClientCredentialType.Windows;
 
-                var uriBuilder = new UriBuilder()
-                {
-                    Scheme = "net.uds",
-                    Path = UDS.GetUDSFilePath()
-                };
+                var uri = new Uri("net.uds://" + UDS.GetUDSFilePath());
                 factory = new System.ServiceModel.ChannelFactory<IEchoService>(binding,
-                    new System.ServiceModel.EndpointAddress(uriBuilder.ToString()));
+                    new System.ServiceModel.EndpointAddress(uri));
                 channel = factory.CreateChannel();
                 ((IChannel)channel).Open();
                 string result = channel.Echo(testString);

--- a/src/System.ServiceModel.UnixDomainSocket/src/System/ServiceModel/Channels/UnixDomainSocketChannelFactory.cs
+++ b/src/System.ServiceModel.UnixDomainSocket/src/System/ServiceModel/Channels/UnixDomainSocketChannelFactory.cs
@@ -40,7 +40,7 @@ namespace System.ServiceModel.Channels
         {
             if(address.Identity == null)
             {
-                var hostIdentity = new DnsEndpointIdentity(address.Uri.Host ?? "localhost");
+                var hostIdentity = new DnsEndpointIdentity(string.IsNullOrEmpty(address.Uri.Host) ? "localhost" : address.Uri.Host);
                 var uriBuilder = new UriBuilder(address.Uri);
                 uriBuilder.Host = null;
                 address = new EndpointAddress(uriBuilder.Uri, hostIdentity,address.Headers.ToArray());


### PR DESCRIPTION
Addresses issue #5621.

Note: 
The fix and the associated test case have been verified locally. It requires the Windows_Authentication_Available condition to be set.
 