### PR TITLE
[release/3.3] Update Linux image pool

### DIFF
--- a/eng/SendToHelix.proj
+++ b/eng/SendToHelix.proj
@@ -26,16 +26,17 @@
 
   <ItemGroup Condition="'$(TestJob)' == 'Windows' AND '$(RunAsInternal)'" >
     <HelixTargetQueue Include="Windows.10.Amd64" />
-    <HelixTargetQueue Include="Debian.9.Amd64" />
-    <HelixTargetQueue Include="RedHat.7.Amd64" />
+    <HelixTargetQueue Include="(Debian.11.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64" />
+    <HelixTargetQueue Include="(Mariner.2.0.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestJob)' == 'Linux'" >
-    <HelixTargetQueue Include="Centos.7.Amd64.Open" />
-    <HelixTargetQueue Include="Debian.9.Amd64.Open" />
-    <HelixTargetQueue Include="RedHat.7.Amd64.Open" />
-    <HelixTargetQueue Include="SLES.12.Amd64.Open" />
-    <HelixTargetQueue Include="Ubuntu.1804.Amd64.Open" />
+    <HelixTargetQueue Include="SLES.15.Amd64.Open" />
+    <HelixTargetQueue Include="(Fedora.38.Amd64.Open)ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-helix" />
+    <HelixTargetQueue Include="Ubuntu.2204.Amd64.Open" />
+    <HelixTargetQueue Include="(Debian.11.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64" />
+    <HelixTargetQueue Include="(Mariner.2.0.Amd64.Open)Ubuntu.2204.Amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64" />
+    <HelixTargetQueue Include="(openSUSE.15.2.Amd64.Open)Ubuntu.2204.Amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:opensuse-15.2-helix-amd64" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestJob)' == 'MacOS'" >

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
@@ -28,8 +28,7 @@ namespace Infrastructure.Common
 
         private static List<Tuple<string, OSID>> _runtimeToOSID = new List<Tuple<string, OSID>>
         {
-            new Tuple<string, OSID>("centos.7", OSID.CentOS_7),
-            new Tuple<string, OSID>("centos.", OSID.AnyCentOS),
+            new Tuple<string, OSID>("mariner", OSID.Mariner),
 
             new Tuple<string, OSID>("debian.9", OSID.Debian_9),
             new Tuple<string, OSID>("debian.8", OSID.Debian_8),

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
@@ -36,9 +36,7 @@ namespace Infrastructure.Common
              Windows_Server_2008 | Windows_Server_2008_R2 | Windows_Server_2012 | Windows_Server_2012_R2 | Windows_Server_2016 |
              WindowsPhone | Windows_Nano,
 
-        CentOS_7 =             0x00000800,
-        CentOS_7_3 =             0x00001000,
-        AnyCentOS = CentOS_7 | CentOS_7_3,
+        Mariner =             0x00000800,
 
         Debian_8 =               0x00002000,
         Debian_9 =               0x00004000,
@@ -71,7 +69,7 @@ namespace Infrastructure.Common
 
         // 'Any' combinations must explicitly name only known flags so "G" formatting
         // can be used to show a comma separated list of the bitmask.
-        AnyUnix = AnyCentOS | AnyDebian | AnyFedora | AnyOpenSUSE | AnyOSX | AnyRHEL | AnyUbuntu,
+        AnyUnix = Mariner | AnyDebian | AnyFedora | AnyOpenSUSE | AnyOSX | AnyRHEL | AnyUbuntu,
 
         Any = AnyUnix | AnyWindows
     }


### PR DESCRIPTION
Removing Cenos and update other Linux images by referring to PR #5369.