### PR TITLE
dotnet-svcutil: generate CloseAsync with preprocessor directive and update test baselines

### DIFF
--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
@@ -7,54 +7,11 @@ using Microsoft.CodeDom;
 using System.ServiceModel;
 using System.Threading.Tasks;
 using System.Linq;
-using System.Xml.Linq;
 
 namespace Microsoft.Tools.ServiceModel.Svcutil
 {
     internal class AddAsyncOpenClose : ClientClassVisitor
     {
-        private bool _generateCloseAsync = false;
-        private bool _addCondition = false;
-
-        public AddAsyncOpenClose(CommandProcessorOptions options)
-        {
-            if (options.Project != null && options.Project.TargetFrameworks.Count() > 1 && options.Project.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo netfxInfo) && !netfxInfo.IsDnx))
-            {
-                _generateCloseAsync = true;
-                FrameworkInfo dnxInfo = null;
-                var tfx = options.Project.TargetFrameworks.FirstOrDefault(t => TargetFrameworkHelper.IsSupportedFramework(t, out dnxInfo) && dnxInfo.IsDnx);
-                if (!string.IsNullOrEmpty(tfx) && dnxInfo.Version.Major >= 6)
-                {
-                    _addCondition = true;
-                }
-            }
-            else
-            {
-                if (options.TargetFramework.IsDnx)
-                {
-                    if (TargetFrameworkHelper.NetCoreVersionReferenceTable.TryGetValue(options.TargetFramework.Version, out var referenceTable))
-                    {
-                        string version = referenceTable.FirstOrDefault().Version;
-                        string[] vers = version.Split('.');
-                        if (vers.Length > 1)
-                        {
-                            Version v = new Version(int.Parse(vers[0]), int.TryParse(vers[1], out int minor) ? minor : 0);
-                            // For .NETCore targetframework found in the referenced table, generate CloseAsync() when WCF package version is less than 4.10
-                            if (v.CompareTo(new Version(4, 10)) < 0)
-                            {
-                                _generateCloseAsync = true;
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    // For supported non-Dnx target frameworks (eg: net472, net48), generate CloseAsync() as before
-                    _generateCloseAsync = true;
-                }
-            }
-        }
-
         protected override void VisitClientClass(CodeTypeDeclaration type)
         {
             base.VisitClientClass(type);
@@ -62,10 +19,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             using (NameScope nameScope = new CodeTypeNameScope(type))
             {
                 type.Members.Add(GenerateTaskBasedAsyncMethod("Open", nameScope));
-                if(_generateCloseAsync)
-                {
-                    type.Members.Add(GenerateTaskBasedAsyncMethod("Close", nameScope));
-                }
+                type.Members.Add(GenerateTaskBasedAsyncMethod("Close", nameScope));
             }
         }
 
@@ -104,9 +58,9 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     GenerateBeginMethodInvokeExpression(methodName),
                     delegateOfEndCall)));
 
-            if(_addCondition && methodName.Equals("Close"))
+            if(methodName.Equals("Close"))
             {
-                CodeIfDirective ifStart = new CodeIfDirective(CodeIfMode.Start, "NETFRAMEWORK");
+                CodeIfDirective ifStart = new CodeIfDirective(CodeIfMode.Start, "!NET6_0_OR_GREATER");
                 CodeIfDirective ifEnd = new CodeIfDirective(CodeIfMode.End, "");
                 implMethod.StartDirectives.Add(ifStart);
                 implMethod.EndDirectives.Add(ifEnd);

--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/VisitorFixup.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/VisitorFixup.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         new SpecialIXmlSerializableRemapper(arrayOfXElementTypeHelper),
                         new EnsureAdditionalAssemblyReference(),
                         new CreateCallbackImpl((generator.Options & ServiceContractGenerationOptions.TaskBasedAsynchronousMethod) == ServiceContractGenerationOptions.TaskBasedAsynchronousMethod, generator),
-                        new AddAsyncOpenClose(options), // this one need to run after CreateCallbakImpl which provide name of VerifyCallbackEvents method
+                        new AddAsyncOpenClose(), // this one need to run after CreateCallbakImpl which provide name of VerifyCallbackEvents method
                         new TypeNameFixup()
                     };
 

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Auto/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Auto/Reference.cs
@@ -889,10 +889,12 @@ namespace Auto_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/CollectionArray/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/CollectionArray/Reference.cs
@@ -889,10 +889,12 @@ namespace CollectionArray_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/DataContractSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/DataContractSerializer/Reference.cs
@@ -889,10 +889,12 @@ namespace DataContractSerializer_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/EnableDataBinding/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/EnableDataBinding/Reference.cs
@@ -1122,10 +1122,12 @@ namespace EnableDataBinding_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/ExcludeType/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/ExcludeType/Reference.cs
@@ -1036,10 +1036,12 @@ namespace ExcludeType_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Internal/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Internal/Reference.cs
@@ -889,10 +889,12 @@ namespace Internal_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/MessageContract/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/MessageContract/Reference.cs
@@ -1239,10 +1239,12 @@ namespace MessageContract_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/NoStdLib/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/NoStdLib/Reference.cs
@@ -1063,10 +1063,12 @@ namespace NoStdLib_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/None/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/None/Reference.cs
@@ -889,10 +889,12 @@ namespace None_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Sync/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Sync/Reference.cs
@@ -1020,10 +1020,12 @@ namespace Sync_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
@@ -1946,10 +1946,12 @@ namespace XmlSerializer_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
@@ -2456,10 +2456,12 @@ namespace wrapped_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/Reference.cs
@@ -889,6 +889,13 @@ namespace array_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/Reference.cs
@@ -889,6 +889,13 @@ namespace arrayList_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/Reference.cs
@@ -889,6 +889,13 @@ namespace collection_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace dictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/Reference.cs
@@ -889,6 +889,13 @@ namespace hashTable_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace hybridDictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/Reference.cs
@@ -889,6 +889,13 @@ namespace linkedList_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/Reference.cs
@@ -889,6 +889,13 @@ namespace list_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace listDictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/Reference.cs
@@ -889,6 +889,13 @@ namespace observableCollection_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace orderedDictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/Reference.cs
@@ -889,6 +889,13 @@ namespace sortedDictionary_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/Reference.cs
@@ -889,6 +889,13 @@ namespace sortedList_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/Reference.cs
@@ -889,6 +889,13 @@ namespace sortedListNonGeneric_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/ContractMemberNamedSystem/ContractMemberNamedSystem/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/ContractMemberNamedSystem/ContractMemberNamedSystem/Reference.cs
@@ -164,6 +164,13 @@ namespace ContractMemberNamedSystem_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/ContractTypeNamedReservedKeyword/ContractTypeNamedReservedKeyword/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/ContractTypeNamedReservedKeyword/ContractTypeNamedReservedKeyword/Reference.cs
@@ -265,6 +265,13 @@ namespace ContractTypeNamedReservedKeyword_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/DuplexCallback/Duplex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/DuplexCallback/Duplex/Reference.cs
@@ -88,6 +88,13 @@ namespace Duplex_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.tcp_nosecurity_callback_IWcfDuplexService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
@@ -752,6 +752,10 @@ namespace Saml2IssuedToken_mex_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(Saml2IssuedToken_mex_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2642,10 +2646,22 @@ namespace Saml2IssuedToken_mex_NS
             return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
@@ -889,10 +889,12 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/Reference.cs
@@ -126,6 +126,13 @@ namespace mexParam_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Service1_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/Reference.cs
@@ -126,6 +126,13 @@ namespace noQuery_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Service1_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/Reference.cs
@@ -126,6 +126,13 @@ namespace singleWsdlQuery_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Service1_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/Reference.cs
@@ -126,6 +126,13 @@ namespace wsdlQuery_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Service1_IService1))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net48/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net48/ServiceReference/Reference.cs
@@ -148,10 +148,12 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/ServiceReference/Reference.cs
@@ -148,6 +148,13 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/ServiceReference/Reference.cs
@@ -148,7 +148,7 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
-        #if NETFRAMEWORK
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/ServiceReference/Reference.cs
@@ -148,10 +148,12 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/Reference.cs
@@ -126,6 +126,13 @@ namespace ServiceReference
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAll/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAll/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocAll_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAllRelative/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAllRelative/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocAllRelative_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullAndWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullAndWildcard/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocFullAndWildcard_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullPath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullPath/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocFullPath_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativeAndWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativeAndWildcard/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocRelativeAndWildcard_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativePath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativePath/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocRelativePath_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlRelXsdWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlRelXsdWildcard/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocWsdlRelXsdWildcard_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcard/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocWsdlWildcard_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcardRelative/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcardRelative/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocWsdlWildcardRelative_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlXsdWildcardRelative/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlXsdWildcardRelative/Reference.cs
@@ -889,6 +889,13 @@ namespace multiDocWsdlXsdWildcardRelative_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/urlNamespace/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/urlNamespace/Reference.cs
@@ -899,6 +899,13 @@ public partial class WcfProjectNServiceClient : System.ServiceModel.ClientBase<I
         return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
     }
     
+    #if !NET6_0_OR_GREATER
+    public virtual System.Threading.Tasks.Task CloseAsync()
+    {
+        return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+    }
+    #endif
+    
     private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
     {
         if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/wildcardNamespace/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/wildcardNamespace/Reference.cs
@@ -889,6 +889,13 @@ namespace TestNamespace
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.defaultEndpoint))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/Reference.cs
@@ -148,6 +148,13 @@ namespace net90_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/Reference.cs
@@ -148,6 +148,13 @@ namespace tfm100_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/Reference.cs
@@ -148,10 +148,12 @@ namespace tfm20_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/Reference.cs
@@ -148,10 +148,12 @@ namespace tfm45_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/Reference.cs
@@ -148,6 +148,13 @@ namespace tfmDefault_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmDefault/Reference.cs
@@ -148,6 +148,13 @@ namespace tfmDefault_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNet60/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNet60/Reference.cs
@@ -148,6 +148,13 @@ namespace tfmNet60_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd20/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd20/Reference.cs
@@ -148,10 +148,12 @@ namespace tfmNetstd20_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd21/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd21/Reference.cs
@@ -148,10 +148,12 @@ namespace tfmNetstd21_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalDefault/Reference.cs
@@ -148,6 +148,13 @@ namespace tfmGlobalDefault_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalNetstd20/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalNetstd20/Reference.cs
@@ -148,10 +148,12 @@ namespace tfmGlobalNetstd20_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping/Reference.cs
@@ -88,6 +88,13 @@ namespace UpdateNetPipeServiceRefBootstrapping
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.NetNamedPipeBinding_IStreamedService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault/Reference.cs
@@ -88,6 +88,13 @@ namespace UpdateNetPipeServiceRefDefault
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.NetNamedPipeBinding_IStreamedService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefBootstrapping
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefDefault
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevels/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevels/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevels
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevelsFull/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevelsFull/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevelsFull
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptionsDefault
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptionsExtraOptions
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptionsExtraOptionsWarn
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptionsFilePath
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptionsFullPath
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptionsRef
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptionsRef2
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions Folder With Spaces/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions Folder With Spaces/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions Folder With Spaces Full/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions Folder With Spaces Full/Reference.cs
@@ -148,10 +148,12 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces_Full
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
         public virtual System.Threading.Tasks.Task CloseAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
         }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/Connected Services/CSServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/Connected Services/CSServiceReference/Reference.cs
@@ -148,6 +148,13 @@ namespace ServiceReference1
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/Connected Services/CSServiceReferenceRoundtrip/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/Connected Services/CSServiceReferenceRoundtrip/Reference.cs
@@ -148,6 +148,13 @@ namespace CSServiceReferenceRoundtrip_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.BasicHttpBinding_ITypeReuseSvc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
@@ -752,6 +752,10 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2642,10 +2646,22 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
@@ -616,8 +616,8 @@ namespace BasicHttp_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttp_NS.TestFaultsResponse> TestFaultsAsync(BasicHttp_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace BasicHttp_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttp_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(BasicHttp_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2642,10 +2646,22 @@ namespace BasicHttp_NS
             return ((BasicHttp_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitDualNs/Reference.cs
@@ -779,6 +779,13 @@ namespace BasicHttpDocLitDualNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorDocLit))
@@ -1071,6 +1078,13 @@ namespace BasicHttpDocLitDualNs_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitSingleNs/Reference.cs
@@ -779,6 +779,13 @@ namespace BasicHttpDocLitSingleNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorDocLit))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncDualNs/Reference.cs
@@ -259,6 +259,13 @@ namespace BasicHttpRpcEncDualNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorRpcEnc))
@@ -378,6 +385,13 @@ namespace BasicHttpRpcEncDualNs_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncSingleNs/Reference.cs
@@ -259,6 +259,13 @@ namespace BasicHttpRpcEncSingleNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorRpcEnc))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitDualNs/Reference.cs
@@ -256,6 +256,13 @@ namespace BasicHttpRpcLitDualNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorRpcLit))
@@ -375,6 +382,13 @@ namespace BasicHttpRpcLitDualNs_NS
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitSingleNs/Reference.cs
@@ -256,6 +256,13 @@ namespace BasicHttpRpcLitSingleNs_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_ICalculatorRpcLit))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpSoap/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpSoap/Reference.cs
@@ -213,6 +213,13 @@ namespace BasicHttpSoap_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_IWcfSoapService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp_4_4_0/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp_4_4_0/Reference.cs
@@ -256,6 +256,13 @@ namespace BasicHttp_4_4_0_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.Basic_IWcfService_4_4_0))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
@@ -616,8 +616,8 @@ namespace BasicHttps_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttps_NS.TestFaultsResponse> TestFaultsAsync(BasicHttps_NS.TestFaultsRequest request);
         
@@ -752,6 +752,10 @@ namespace BasicHttps_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttps_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(BasicHttps_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2642,10 +2646,22 @@ namespace BasicHttps_NS
             return ((BasicHttps_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
@@ -752,6 +752,10 @@ namespace NetHttp_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttp_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(NetHttp_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2642,10 +2646,22 @@ namespace NetHttp_NS
             return ((NetHttp_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
@@ -752,6 +752,10 @@ namespace NetHttpWebSockets_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpWebSockets_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(NetHttpWebSockets_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2649,10 +2653,22 @@ namespace NetHttpWebSockets_NS
             return ((NetHttpWebSockets_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
@@ -752,6 +752,10 @@ namespace NetHttps_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttps_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(NetHttps_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2642,10 +2646,22 @@ namespace NetHttps_NS
             return ((NetHttps_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
@@ -752,6 +752,10 @@ namespace NetHttpsWebSockets_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpsWebSockets_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(NetHttpsWebSockets_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2649,10 +2653,22 @@ namespace NetHttpsWebSockets_NS
             return ((NetHttpsWebSockets_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
@@ -752,6 +752,10 @@ namespace TcpTransSecMessCredsUserName_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2649,10 +2653,22 @@ namespace TcpTransSecMessCredsUserName_NS
             return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeReliableSessionSvc/ReliableSessionService/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeReliableSessionSvc/ReliableSessionService/Reference.cs
@@ -81,6 +81,13 @@ namespace ReliableSessionService_NS
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
         
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
+        
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {
             if ((endpointConfiguration == EndpointConfiguration.NetHttpOrdered_WSReliableMessaging11_IWcfReliableService))

--- a/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
@@ -752,6 +752,10 @@ namespace HttpsTransSecMessCredsUserName_NS
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/GetRequestHttpHeaders", ReplyAction="http://tempuri.org/IWcfService/GetRequestHttpHeadersResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync(HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/EchoReturnTask", ReplyAction="http://tempuri.org/IWcfService/EchoReturnTaskResponse")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        System.Threading.Tasks.Task EchoReturnTaskAsync();
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -2642,10 +2646,22 @@ namespace HttpsTransSecMessCredsUserName_NS
             return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
         }
         
+        public System.Threading.Tasks.Task EchoReturnTaskAsync()
+        {
+            return base.Channel.EchoReturnTaskAsync();
+        }
+        
         public virtual System.Threading.Tasks.Task OpenAsync()
         {
             return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginOpen(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndOpen));
         }
+        
+        #if !NET6_0_OR_GREATER
+        public virtual System.Threading.Tasks.Task CloseAsync()
+        {
+            return System.Threading.Tasks.Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(this)).BeginClose(null, null), new System.Action<System.IAsyncResult>(((System.ServiceModel.ICommunicationObject)(this)).EndClose));
+        }
+        #endif
         
         private static System.ServiceModel.Channels.Binding GetBindingForEndpoint(EndpointConfiguration endpointConfiguration)
         {

--- a/src/dotnet-svcutil/lib/tests/src/E2ETests.cs
+++ b/src/dotnet-svcutil/lib/tests/src/E2ETests.cs
@@ -120,7 +120,7 @@ namespace SvcutilTest
             InitializeE2E(testCaseName);
 
             var uri = Path.Combine(g_TestCasesDir, "wsdl", "WcfProjectNService", "tempuri.org.wsdl");
-            var options = $"{uri} {optionModifier} -nl -tf netcoreapp1.0";
+            var options = $"{uri} {optionModifier} -nl -tf net8.0";
             this_TestCaseName = testCaseName;
             TestSvcutil(AppendCommonOptions(options));
         }

--- a/src/dotnet-svcutil/lib/tests/src/GlobalToolTests.cs
+++ b/src/dotnet-svcutil/lib/tests/src/GlobalToolTests.cs
@@ -108,10 +108,10 @@ namespace SvcutilTest
 
         [Trait("Category", "BVT")]
         [Theory]
-        [InlineData("net48")] //System.ServiceModel get referened and CloseAsync() is generated
-        [InlineData("netstd20")] //WCF package older than V4.10 get referened and CloseAsync() is generated
-        [InlineData("net60")] //WCF package newer than V4.10 get referened and CloseAsync() is not generated
-        [InlineData("net60net48")] //WCF package newer than V4.10 and System.ServiceModel.dll are referenced conditionally by target and CloseAsync() be generarted with conditional compilation mark
+        [InlineData("net48")] //System.ServiceModel get referened and CloseAsync() is generated with Target Framework Preprocessor Directive 
+        [InlineData("netstd20")] //WCF package V4.10 get referened and CloseAsync() is generated with TFPD
+        [InlineData("net60")] //WCF package V6.2 get referened and CloseAsync() is generated with TFPD
+        [InlineData("net60net48")] //WCF package V6.2 and System.ServiceModel.dll are referenced conditionally by target and CloseAsync() is generated with TFPD
         public async Task MultiTargetCloseAsyncGeneration(string testCaseName)
         {
             this_TestCaseName = "MultiTargetCloseAsyncGeneration";


### PR DESCRIPTION
Split PR #5519 - Part 1

**Description**: Added the `!NET6_0_OR_GREATER` preprocessor directive to the generated code for the `CloseAsync()` method to accommodate product upgrades, and updated the affected test baselines accordingly.