### PR TITLE
dotnet-svcutil: refine TFX resolution and the referenced WCF versions, and update test baselines.

### DIFF
--- a/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
+++ b/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -667,6 +668,18 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 
         private async Task ProcessTargetFrameworkOptionAsync(CancellationToken cancellationToken)
         {
+            if(this.Project != null)
+            {
+                this.Project.EndOfLifeTargetFrameworks?.ToList().ForEach(tfx => this.AddWarning(string.Format(CultureInfo.CurrentCulture, SR.WrnOutOfSupportTargetFrameworkFormat, tfx)));
+            }
+            else
+            {
+                if (TargetFrameworkHelper.IsEndofLifeFramework(this.TargetFramework?.FullName))
+                {
+                    this.AddWarning(string.Format(CultureInfo.CurrentCulture, SR.WrnOutOfSupportTargetFrameworkFormat, this.TargetFramework.FullName));
+                }
+            }
+
             if (this.TargetFramework == null)
             {
                 var targetFrameworkMoniker = string.Empty;

--- a/src/dotnet-svcutil/lib/src/SR.resx
+++ b/src/dotnet-svcutil/lib/src/SR.resx
@@ -625,4 +625,7 @@ Your credentials will be sent to the server in clear text.</value>
   <data name="WrnTargetFrameworkNotSupported_NetNamedPipe" xml:space="preserve">
     <value>NetNamedPipe is not supported on current .net target framework.</value>
   </data>
+  <data name="WrnOutOfSupportTargetFrameworkFormat" xml:space="preserve">
+    <value>The target framework '{0}' is out of support and will not receive security updates in the future.</value>
+  </data>
 </root>

--- a/src/dotnet-svcutil/lib/src/Shared/FrameworkInfo.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/FrameworkInfo.cs
@@ -110,9 +110,11 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             fxInfo.Name = name;
             fxInfo.Version = version;
             fxInfo.IsDnx = name == Netstandard || name == Netcoreapp || version.Major >= 5;
+            // A .NET version is known DNX if it's dnx: netstandard with version <= MaxSupportedNetStandardVersion, 
+            // or non-netstandard with version <= MaxSupportedNetCoreAppVersion.
             fxInfo.IsKnownDnx = fxInfo.IsDnx &&
-                        ((name == Netstandard && TargetFrameworkHelper.NetStandardToNetCoreVersionMap.Keys.Any((netstdVersion) => netstdVersion == version)) ||
-                         (name != Netstandard && TargetFrameworkHelper.NetCoreToWCFPackageReferenceVersionMap.Keys.Any((netcoreVersion) => netcoreVersion == version)));
+                        ((name == Netstandard && version <= TargetFrameworkHelper.MaxSupportedNetStandardVersion) ||
+                         (name != Netstandard && version <= TargetFrameworkHelper.MaxSupportedNetCoreAppVersion));
 
             return fxInfo;
         }

--- a/src/dotnet-svcutil/lib/src/Shared/FrameworkInfo.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/FrameworkInfo.cs
@@ -78,18 +78,19 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 
             if (name.ToLower().Contains(Netversion))
             {
-                //.NETStandard,Version=v2.0 => netstandard2.0
+                //TFMoniker form ".NETStandard,Version=v2.0" resolves to framework name "netstandard."
                 if (name.ToLower().Contains(Netstandard))
                 {
                     name = Netstandard;
                 }
-                //.NETFramework,Version=v4.8 => net4.8
-                //.NETCoreApp,Version=v6.0 => net6.0
+                //TFMoniker form ".NETFramework,Version=v4.8" resolves to framework name "net"
+                //TFMoniker form ".NETCoreApp,Version=v6.0" resolves to framework name "net"
                 else if (name.ToLower().Contains(Netframework) || version.Major >= 5)
                 {
                     name = Netfx;
                 }
-                //.NETCoreApp,Version=v3.1 => netcoreapp3.1
+
+                //TFMoniker form ".NETCoreApp,Version=v3.1" resolves to framework name "netcoreapp"
                 else
                 {
                     name = Netcoreapp;

--- a/src/dotnet-svcutil/lib/src/Shared/FrameworkInfo.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/FrameworkInfo.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         public string Name { get; private set; }
         public Version Version { get; private set; }
         public bool IsDnx { get; private set; }
-        public bool IsKnownDnx { get; private set; }
 
         public static FrameworkInfo Parse(string fullFrameworkName)
         {
@@ -110,11 +109,6 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             fxInfo.Name = name;
             fxInfo.Version = version;
             fxInfo.IsDnx = name == Netstandard || name == Netcoreapp || version.Major >= 5;
-            // A .NET version is known DNX if it's dnx: netstandard with version <= MaxSupportedNetStandardVersion, 
-            // or non-netstandard with version <= MaxSupportedNetCoreAppVersion.
-            fxInfo.IsKnownDnx = fxInfo.IsDnx &&
-                        ((name == Netstandard && version <= TargetFrameworkHelper.MaxSupportedNetStandardVersion) ||
-                         (name != Netstandard && version <= TargetFrameworkHelper.MaxSupportedNetCoreAppVersion));
 
             return fxInfo;
         }

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -43,7 +43,9 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         }
 
         private List<string> _targetFrameworks = new List<string>();
+        private List<string> _endOfLifeTargetFrameworks = new List<string>();
         public IEnumerable<string> TargetFrameworks { get { return _targetFrameworks; } }
+        public IEnumerable<string> EndOfLifeTargetFrameworks { get { return _endOfLifeTargetFrameworks; } }
 
         private string _runtimeIdentifier;
         public string RuntimeIdentifier
@@ -358,7 +360,13 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 
                 var sdkVersion = await ProjectPropertyResolver.GetSdkVersionAsync(msbuildProj.DirectoryPath, logger, cancellationToken).ConfigureAwait(false);
                 msbuildProj.SdkVersion = sdkVersion ?? string.Empty;
-
+                foreach (var tfx in msbuildProj._targetFrameworks)
+                {
+                    if(TargetFrameworkHelper.IsEndofLifeFramework(tfx))
+                    {
+                        msbuildProj._endOfLifeTargetFrameworks.Add(tfx);
+                    }
+                }
                 return msbuildProj;
             }
         }

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -133,15 +133,6 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     {
                         _packageReferenceGroup = refItems.FirstOrDefault().Parent;
                     }
-
-                    if (this.TargetFrameworks.Count() > 1 && this.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo netfxInfo) && !netfxInfo.IsDnx))
-                    {
-                        Version ver = TargetFrameworkHelper.GetLowestNetCoreVersion(this.TargetFrameworks);
-                        if (ver != null && ver.Major >= 6)
-                        {
-                            _packageReferenceGroup.Add(new XAttribute("Condition", $"!$(TargetFramework.StartsWith('net4'))"));
-                        }
-                    }
                 }
 
                 return _packageReferenceGroup;
@@ -539,19 +530,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         this.ProjectReferceGroup.Add(new XElement("ProjectReference", new XAttribute("Include", dependency.FullPath)));
                         break;
                     case ProjectDependencyType.Binary:
-                        Version ver = TargetFrameworkHelper.GetLowestNetCoreVersion(this.TargetFrameworks);
-                        if (this.TargetFrameworks.Count() > 1 && dependency.Name.Equals(TargetFrameworkHelper.FullFrameworkReferences.FirstOrDefault().Name)
-                            && ver != null && ver.Major >= 6)
-                        {
-                            if (this.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo netfxInfo) && !netfxInfo.IsDnx))
-                            {
-                                this.ReferenceGroup.Add(new XElement("Reference", new XAttribute("Condition", $"$(TargetFramework.StartsWith('net4'))"), new XAttribute("Include", dependency.AssemblyName), new XElement("HintPath", dependency.FullPath)));
-                            }
-                        }
-                        else
-                        {
-                            this.ReferenceGroup.Add(new XElement("Reference", new XAttribute("Include", dependency.AssemblyName), new XElement("HintPath", dependency.FullPath)));
-                        }
+                        this.ReferenceGroup.Add(new XElement("Reference", new XAttribute("Include", dependency.AssemblyName), new XElement("HintPath", dependency.FullPath)));
                         break;
                     case ProjectDependencyType.Package:
                         this.PacakgeReferenceGroup.Add(new XElement("PackageReference", new XAttribute("Include", dependency.Name), new XAttribute("Version", dependency.Version)));

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -233,9 +233,9 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     }
                     else
                     {
-                        msbuildProj._targetFramework = string.Concat("net", TargetFrameworkHelper.MinNetVersionForLatestWCFPackages.ToString());
+                        msbuildProj._targetFramework = string.Concat("net", TargetFrameworkHelper.s_supportedVersions.First());
                     }
-                    
+
                     msbuildProj._targetFrameworks.Add(msbuildProj._targetFramework);
                 }
 

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     }
                     else
                     {
-                        msbuildProj._targetFramework = string.Concat("net", TargetFrameworkHelper.s_supportedVersions.First());
+                        msbuildProj._targetFramework = string.Concat("net", TargetFrameworkHelper.s_currentSupportedVersions.First());
                     }
 
                     msbuildProj._targetFrameworks.Add(msbuildProj._targetFramework);

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     }
                     else
                     {
-                        msbuildProj._targetFramework = string.Concat("net", TargetFrameworkHelper.NetCoreVersionReferenceTable.LastOrDefault().Key.ToString());
+                        msbuildProj._targetFramework = string.Concat("net", TargetFrameworkHelper.MinNetVersionForLatestWCFPackages.ToString());
                     }
                     
                     msbuildProj._targetFrameworks.Add(msbuildProj._targetFramework);

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         private List<string> _targetFrameworks = new List<string>();
         private List<string> _endOfLifeTargetFrameworks = new List<string>();
         public IEnumerable<string> TargetFrameworks { get { return _targetFrameworks; } }
-        public IEnumerable<string> EndOfLifeTargetFrameworks { get { return _endOfLifeTargetFrameworks; } }
+        internal IEnumerable<string> EndOfLifeTargetFrameworks { get { return _endOfLifeTargetFrameworks; } }
 
         private string _runtimeIdentifier;
         public string RuntimeIdentifier

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -13,10 +13,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 {
     internal class TargetFrameworkHelper
     {
-        private static readonly Version s_minEOFNetVersion = new Version("5.0");
-        private static readonly Version s_maxEOFNetVersion = new Version("7.0");
-        internal static readonly List<string> s_supportedVersions = new List<string>() { "8.0", "9.0", "10.0" };
-        
+        internal static readonly List<string> s_currentSupportedVersions = new List<string>() { "8.0", "9.0" };
         public static Version MinSupportedNetFxVersion { get; } = new Version("4.5");
         public static Version MinSupportedNetStandardVersion { get; } = new Version("1.3");
         public static Version MinSupportedNetCoreAppVersion { get; } = new Version("1.0");
@@ -74,7 +71,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             // netstandard2.0;net8.0:  add WCF reference 8.*
             // netstandard2.0;net6.0:  add WCF reference 4.10.*
             // net6.0;net8.0        :  add WCF reference 4.10.*
-            if (netCoreVersion != null && s_supportedVersions.Contains(netCoreVersion.ToString()))
+            if (netCoreVersion != null && s_currentSupportedVersions.Contains(netCoreVersion.ToString()))
             {
                 return NetCoreVersionReferenceTable["Current"];
             }
@@ -152,11 +149,10 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         {
             if (FrameworkInfo.TryParse(fullFrameworkName, out FrameworkInfo frameworkInfo))
             {
-                // Return true if .NETCoreApp or .NET version is within the end-of-life range
-                return frameworkInfo.Name.Equals(FrameworkInfo.Netcoreapp, StringComparison.OrdinalIgnoreCase) ||
-                       (frameworkInfo.Name.Equals(FrameworkInfo.Netfx, StringComparison.OrdinalIgnoreCase) &&
-                        frameworkInfo.Version >= s_minEOFNetVersion &&
-                        frameworkInfo.Version <= s_maxEOFNetVersion);
+                // Return true if .NET version is less than the lowest supported Version
+                return frameworkInfo.IsDnx
+                    && !frameworkInfo.Name.Equals(FrameworkInfo.Netstandard, StringComparison.OrdinalIgnoreCase)
+                    && frameworkInfo.Version < new Version(s_currentSupportedVersions.First());
             }
 
             // Return false if parsing fails or no conditions matched

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
              {new Version("3.0"), new Version("2.0") },
              {new Version("3.1"), new Version("2.0") },
              {new Version("5.0"), new Version("2.0") },
-             {new Version("6.0"), new Version("6.0") },
-             {new Version("7.0"), new Version("6.0") },
+             {new Version("6.0"), new Version("2.0") },
+             {new Version("7.0"), new Version("2.0") },
              {new Version("8.0"), new Version("8.0") }
          });
 
@@ -49,16 +49,10 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 ProjectDependency.FromPackage("System.ServiceModel.Security", "4.10.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.Federation", "4.10.*")
             } },
-            {new Version("6.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "6.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "6.*")
-            } },
             {new Version("8.0"), new List<ProjectDependency> {
                 ProjectDependency.FromPackage("System.ServiceModel.Http", "8.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "8.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.Primitives", "8.*")
-                
             } }
         };
 

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 {
     internal class TargetFrameworkHelper
     {
+        private static readonly int s_minEOFNetVersion = 5;
+        private static readonly int s_maxEOFNetVersion = 7;
+
         public static ReadOnlyDictionary<Version, Version> NetStandardToNetCoreVersionMap { get; } = new ReadOnlyDictionary<Version, Version>(new SortedDictionary<Version, Version>
          {
             // Service Model requires netstandard1.3 so it is the minimum version that will work.
@@ -192,6 +195,21 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             }
 
             return isSupported;
+        }
+
+        public static bool IsEndofLifeFramework(string fullFrameworkName)
+        {
+            if (FrameworkInfo.TryParse(fullFrameworkName, out FrameworkInfo frameworkInfo))
+            {
+                // Return true if .NETCoreApp or .NET version is within the end-of-life range
+                return frameworkInfo.Name.Equals(FrameworkInfo.Netcoreapp, StringComparison.OrdinalIgnoreCase) ||
+                       (frameworkInfo.Name.Equals(FrameworkInfo.Netfx, StringComparison.OrdinalIgnoreCase) &&
+                        frameworkInfo.Version.Major >= s_minEOFNetVersion &&
+                        frameworkInfo.Version.Major <= s_maxEOFNetVersion);
+            }
+
+            // Return false if parsing fails or no conditions matched
+            return false;
         }
 
         public static bool ContainsFullFrameworkTarget(IEnumerable<string> targetFrameworks)

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -50,13 +50,9 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 ProjectDependency.FromPackage("System.ServiceModel.Federation", "4.10.*")
             } },
             {new Version("6.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Federation", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.UnixDomainSocket", "6.2.*"),
-                ProjectDependency.FromPackage("System.Web.Services.Description", "6.2.*")
+                ProjectDependency.FromPackage("System.ServiceModel.Http", "6.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "6.*")
             } },
             {new Version("8.0"), new List<ProjectDependency> {
                 ProjectDependency.FromPackage("System.ServiceModel.Http", "8.*"),

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
     internal class TargetFrameworkHelper
     {
         internal static readonly List<string> s_currentSupportedVersions = new List<string>() { "8.0", "9.0" };
-        public static Version MinSupportedNetFxVersion { get; } = new Version("4.5");
+        public static Version MinSupportedNetFxVersionForDotNet { get; } = new Version("4.5");
         public static Version MinSupportedNetStandardVersion { get; } = new Version("1.3");
         public static Version MinSupportedNetCoreAppVersion { get; } = new Version("1.0");
 
@@ -126,7 +126,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             if (!IsSupportedFramework(targetFramework, out FrameworkInfo frameworkInfo))
             {
                 throw new Exception(string.Format(CultureInfo.CurrentCulture, Shared.Resources.ErrorNotSupportedTargetFrameworkFormat,
-                                                  targetFramework, MinSupportedNetCoreAppVersion, MinSupportedNetStandardVersion, MinSupportedNetFxVersion));
+                                                  targetFramework, MinSupportedNetCoreAppVersion, MinSupportedNetStandardVersion, MinSupportedNetFxVersionForDotNet));
             }
             return frameworkInfo;
         }
@@ -139,7 +139,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             {
                 isSupported = (frameworkInfo.Name == FrameworkInfo.Netstandard && frameworkInfo.Version >= MinSupportedNetStandardVersion) ||
                               (frameworkInfo.Name == FrameworkInfo.Netcoreapp && frameworkInfo.Version >= MinSupportedNetCoreAppVersion) ||
-                              (frameworkInfo.Name == FrameworkInfo.Netfx && frameworkInfo.Version >= MinSupportedNetFxVersion);
+                              (frameworkInfo.Name == FrameworkInfo.Netfx && frameworkInfo.Version >= MinSupportedNetFxVersionForDotNet);
             }
 
             return isSupported;

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -21,60 +21,35 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
              {new Version("1.5"), new Version("1.0") },
              {new Version("1.6"), new Version("1.0") },
              {new Version("1.6.1"), new Version("1.1") },
-             {new Version("2.0"), new Version("2.0") }
+             {new Version("2.0"), new Version("2.0") },
+             {new Version("2.1"), new Version("3.1") }
+         });
+
+        public static ReadOnlyDictionary<Version, Version> NetCoreToWCFPackageReferenceVersionMap { get; } = new ReadOnlyDictionary<Version, Version>(new SortedDictionary<Version, Version>
+         {
+             {new Version("1.0"), new Version("2.0") },
+             {new Version("1.1"), new Version("2.0") },
+             {new Version("2.0"), new Version("2.0") },
+             {new Version("2.1"), new Version("2.0") },
+             {new Version("2.2"), new Version("2.0") },
+             {new Version("3.0"), new Version("2.0") },
+             {new Version("3.1"), new Version("2.0") },
+             {new Version("5.0"), new Version("2.0") },
+             {new Version("6.0"), new Version("6.0") },
+             {new Version("7.0"), new Version("6.0") },
+             {new Version("8.0"), new Version("8.0") }
          });
 
         internal static SortedDictionary<Version, List<ProjectDependency>> NetCoreVersionReferenceTable = new SortedDictionary<Version, List<ProjectDependency>>
         {
-            {new Version("1.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.0.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.1.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.1.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.0.*"),
-                ProjectDependency.FromPackage("System.Xml.XmlSerializer", "4.0.*"    ),
-            } },
-            {new Version("1.1"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.3.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.3.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.3.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.3.*"),
-                ProjectDependency.FromPackage("System.Xml.XmlSerializer", "4.3.*"    ),
-            } },
             {new Version("2.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.4.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.4.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.4.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.4.*"),
-            } },
-            {new Version("2.1"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.6.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.6.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.6.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.6.*"),
-            } },
-            {new Version("3.1"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.7.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.7.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.7.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.7.*"),
-             } },
-            {new Version("5.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.8.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.8.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.8.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Federation", "4.8.*")
+                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "4.10.*"  ),
+                ProjectDependency.FromPackage("System.ServiceModel.Http", "4.10.*"    ),
+                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.10.*"  ),
+                ProjectDependency.FromPackage("System.ServiceModel.Security", "4.10.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.Federation", "4.10.*")
             } },
             {new Version("6.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Federation", "6.2.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.UnixDomainSocket", "6.2.*"),
-                ProjectDependency.FromPackage("System.Web.Services.Description", "6.2.*")
-            } },
-            {new Version("7.0"), new List<ProjectDependency> {
                 ProjectDependency.FromPackage("System.ServiceModel.Http", "6.2.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.2.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "6.2.*"),
@@ -86,11 +61,8 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             {new Version("8.0"), new List<ProjectDependency> {
                 ProjectDependency.FromPackage("System.ServiceModel.Http", "8.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Federation", "8.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.UnixDomainSocket", "8.*"),
-                ProjectDependency.FromPackage("System.Web.Services.Description", "8.*")
+                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "8.*")
+                
             } }
         };
 
@@ -118,27 +90,17 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         public static Version MinSupportedNetStandardVersion { get; } = NetStandardToNetCoreVersionMap.Keys.First();
         public static Version MinSupportedNetCoreAppVersion { get; } = NetStandardToNetCoreVersionMap.Values.First();
 
-        public static IEnumerable<ProjectDependency> GetWcfProjectReferences(string targetFramework)
+        public static IEnumerable<ProjectDependency> GetWcfProjectReferences(IEnumerable<string> targetFrameworks)
         {
             IEnumerable<ProjectDependency> dependencies = null;
-
-            if (IsSupportedFramework(targetFramework, out var frameworkInfo))
+            Version version = GetLowestNetCoreVersion(targetFrameworks);
+            if (version != null)
             {
-                if (frameworkInfo.IsDnx)
-                {
-                    if (NetCoreVersionReferenceTable.ContainsKey(frameworkInfo.Version))
-                    {
-                        dependencies = NetCoreVersionReferenceTable[frameworkInfo.Version];
-                    }
-                    else
-                    {
-                        dependencies = NetCoreVersionReferenceTable.Last().Value;
-                    }
-                }
-                else
-                {
-                    dependencies = FullFrameworkReferences;
-                }
+                dependencies = NetCoreVersionReferenceTable[NetCoreToWCFPackageReferenceVersionMap[version]];
+            }
+            else
+            {
+                dependencies = FullFrameworkReferences;
             }
 
             return dependencies;
@@ -181,25 +143,31 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 if (TargetFrameworkHelper.IsSupportedFramework(targetFramework, out var frameworkInfo) && frameworkInfo.IsDnx)
                 {
                     Version netCoreVersion;
-
                     if (frameworkInfo.IsKnownDnx)
                     {
-                        netCoreVersion = frameworkInfo.Name == FrameworkInfo.Netstandard ?
-                           TargetFrameworkHelper.NetStandardToNetCoreVersionMap[frameworkInfo.Version] :
-                           frameworkInfo.Version;
-                    }
-                    else
-                    {
-                        // target framework is not the minumum standard supported netcore version but it is a known shipped netcore version.
-                        if (TargetFrameworkHelper.NetCoreVersionReferenceTable.ContainsKey(frameworkInfo.Version))
+                        if (frameworkInfo.Name == FrameworkInfo.Netstandard)
                         {
-                            netCoreVersion = frameworkInfo.Version;
+                            if (!NetStandardToNetCoreVersionMap.TryGetValue(frameworkInfo.Version, out netCoreVersion))
+                            {
+                                netCoreVersion = NetStandardToNetCoreVersionMap.LastOrDefault().Value;
+                            }
                         }
                         else
                         {
-                            // target framework is not known to the tool, use the latest known netcore version.
-                            netCoreVersion = TargetFrameworkHelper.NetCoreVersionReferenceTable.Keys.LastOrDefault();
+                            if (NetCoreToWCFPackageReferenceVersionMap.TryGetValue(frameworkInfo.Version, out Version version))
+                            {
+                                netCoreVersion = frameworkInfo.Version;
+                            }
+                            else
+                            {
+                                netCoreVersion = NetCoreToWCFPackageReferenceVersionMap.Keys.LastOrDefault();
+                            }
                         }
+                    }
+                    else
+                    {
+                        // target framework is not known to the tool, use the latest known netcore version.
+                        netCoreVersion = NetCoreToWCFPackageReferenceVersionMap.Keys.LastOrDefault();
                     }
 
                     if (targetVersion == null || targetVersion > netCoreVersion)

--- a/src/dotnet-svcutil/lib/src/Tool.cs
+++ b/src/dotnet-svcutil/lib/src/Tool.cs
@@ -278,22 +278,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     bool needSave = false;
                     foreach (var dep in dependencies)
                     {
-                        if (dep.Name.Contains("NetNamedPipe") && !project.TargetFrameworks.Any(t => t.ToLower().Contains("windows")))
-                        {
-                            continue;
-                        }
-
                         needSave |= project.AddDependency(dep);
-                    }
-
-                    if (project.TargetFrameworks.Count() > 1 && project.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo fxInfo) && !fxInfo.IsDnx))
-                    {
-                        FrameworkInfo fxInfo = null;
-                        Version ver = TargetFrameworkHelper.GetLowestNetCoreVersion(project.TargetFrameworks);
-                        if (ver != null && ver.Major >= 6)
-                        {
-                            needSave |= project.AddDependency(TargetFrameworkHelper.FullFrameworkReferences.FirstOrDefault());
-                        }
                     }
 
                     if (needSave)

--- a/src/dotnet-svcutil/lib/src/Tool.cs
+++ b/src/dotnet-svcutil/lib/src/Tool.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         {
             try
             {
-                var dependencies = TargetFrameworkHelper.GetWcfProjectReferences(project.TargetFramework);
+                var dependencies = TargetFrameworkHelper.GetWcfProjectReferences(project.TargetFrameworks);
                 if (dependencies != null)
                 {
                     bool needSave = false;
@@ -289,8 +289,8 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     if (project.TargetFrameworks.Count() > 1 && project.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo fxInfo) && !fxInfo.IsDnx))
                     {
                         FrameworkInfo fxInfo = null;
-                        var tfx = project.TargetFrameworks.FirstOrDefault(t => TargetFrameworkHelper.IsSupportedFramework(t, out fxInfo) && fxInfo.IsDnx);
-                        if (!string.IsNullOrEmpty(tfx) && fxInfo.Version.Major >= 6)
+                        Version ver = TargetFrameworkHelper.GetLowestNetCoreVersion(project.TargetFrameworks);
+                        if (ver != null && ver.Major >= 6)
                         {
                             needSave |= project.AddDependency(TargetFrameworkHelper.FullFrameworkReferences.FirstOrDefault());
                         }

--- a/src/dotnet-svcutil/lib/src/Tool.cs
+++ b/src/dotnet-svcutil/lib/src/Tool.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 else
                 {
                     // Show early warnings
-                    var earlyWarnings = options.Warnings;
+                    var earlyWarnings = options.Warnings.ToList();
                     foreach (string warning in earlyWarnings.Distinct())
                     {
                         ToolConsole.WriteWarning(warning);

--- a/src/dotnet-svcutil/lib/src/ToolConsole.cs
+++ b/src/dotnet-svcutil/lib/src/ToolConsole.cs
@@ -135,7 +135,23 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         str = logTag + str.Replace(Environment.NewLine, newLineReplacement);
                     }
 
-                    Console.WriteLine(str);
+                    var originalColor = Console.ForegroundColor;
+                    if (logTag == LogTag.Warning)
+                    {
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        Console.WriteLine(str);
+                        Console.ForegroundColor = originalColor;
+                    }
+                    else if (logTag == LogTag.Error)
+                    {
+                        Console.ForegroundColor = ConsoleColor.Red;
+                        Console.WriteLine(str);
+                        Console.ForegroundColor = originalColor;
+                    }
+                    else
+                    {
+                        Console.WriteLine(str);
+                    }
                 }
             }
         }

--- a/src/dotnet-svcutil/lib/src/xlf/SR.cs.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.cs.xlf
@@ -812,6 +812,11 @@ Pokud jste se pokoušeli vygenerovat klienta, může k tomuto dojít v případ�
         <target state="translated">Koncový bod {0} na adrese {1} obsahuje nejméně jednu vazbu, která není kompatibilní s aplikacemi .NET Core. Přeskakování...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">Hodnota zadaná pomocí možnosti --{0} se překládá na cestu k souboru {1}, která se nenachází v adresáři projektu {2}. Je možné, že se soubor nezkompiluje!</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.de.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.de.xlf
@@ -812,6 +812,11 @@ Wenn Sie versucht haben, einen Client zu generieren, könnte die Ursache hierfü
         <target state="translated">Der Endpunkt "{0}" an der Adresse "{1}" enthält mindestens eine Bindung, die nicht mit .NET Core-Apps kompatibel ist. Wird übersprungen...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">Der mit der Option --{0} angegebene Wert wird in den Dateipfad "{1}" aufgelöst, der nicht unter dem Verzeichnis des Projekts "{2}" vorhanden ist. Die Datei wird möglicherweise nicht kompiliert.</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.es.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.es.xlf
@@ -812,6 +812,11 @@ Si intentaba generar un cliente, es posible que se deba a que los documentos de 
         <target state="translated">El punto de conexión "{0}" en la dirección "{1}" contiene uno o varios enlaces no compatibles con las aplicaciones de .Net Core, omitiendo...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">El valor especificado con la opción --{0} se resuelve en la ruta de acceso de archivo "{1}", que no está en el directorio del proyecto "{2}". El archivo no puede compilarse.</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.fr.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.fr.xlf
@@ -812,6 +812,11 @@ Si vous avez tenté de générer un client, cela peut être dû au fait que les 
         <target state="translated">Le point de terminaison '{0}' à l'adresse '{1}' contient une ou plusieurs liaisons non compatibles avec les applications .Net Core. Il va être ignoré...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">La valeur spécifiée avec l'option --{0} correspond au chemin de fichier '{1}' qui ne se trouve pas dans le répertoire du projet '{2}'. Le fichier risque de ne pas être compilé !</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.it.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.it.xlf
@@ -812,6 +812,11 @@ Se si stava provando a creare un client, il problema può dipendere dal fatto ch
         <target state="translated">L'endpoint '{0}' all'indirizzo '{1}' contiene uno o più binding non compatibili con le app .NET Core. Verrà ignorato...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">Il valore specificato con l'opzione --{0} viene risolto nel percorso del file '{1}' che non si trova nella directory del progetto '{2}'. È possibile che il file non venga compilato.</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.ja.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.ja.xlf
@@ -812,6 +812,11 @@ If you were trying to generate a client, this could be because the metadata docu
         <target state="translated">アドレス '{1}' のエンドポイント '{0}' に、.Net Core アプリと互換性のないバインドが 1 つ以上含まれています。スキップしています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">--{0} オプションで指定された値はファイル パス '{1}' に解決されますが、このパスはプロジェクト '{2}' のディレクトリの下にありません。このファイルはコンパイルされない可能性があります。</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.ko.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.ko.xlf
@@ -812,6 +812,11 @@ If you were trying to generate a client, this could be because the metadata docu
         <target state="translated">주소 '{1}'의 엔드포인트 '{0}'에 .NET Core 앱과 호환되지 않는 바인딩이 하나 이상 있습니다. 건너뜁니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">--{0} 옵션으로 지정된 값은 '{2}' 프로젝트의 디렉터리 아래에 없는 '{1}' 파일 경로로 확인됩니다. 파일이 컴파일되지 않을 수 있습니다.</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.pl.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.pl.xlf
@@ -812,6 +812,11 @@ Jeśli próbowano wygenerować klienta, może być to spowodowane przez dokument
         <target state="translated">Punkt końcowy „{0}” pod adresem „{1}” zawiera co najmniej jedno powiązanie, które nie jest zgodne z aplikacjami .Net Core. Są one pomijane...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">Wartość opcji --{0} jest rozpoznawana jako ścieżka „{1}”, która znajduje się poza katalogiem projektu „{2}”. Kompilowanie pliku może zakończyć się niepowodzeniem.</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.pt-BR.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.pt-BR.xlf
@@ -812,6 +812,11 @@ Se você estava tentando gerar um cliente, isso pode ter acontecido porque os do
         <target state="translated">O ponto de extremidade '{0}' no endereço '{1}' contém uma ou mais associações não compatíveis com os aplicativos .Net Core. Ignorando...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">O valor especificado com a opção --{0} resolve para o caminho de arquivo '{1}', que não está sob o diretório do projeto '{2}'. O arquivo não pode ser compilado!</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.ru.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.ru.xlf
@@ -812,6 +812,11 @@ If you were trying to generate a client, this could be because the metadata docu
         <target state="translated">Конечная точка "{0}" по адресу "{1}" содержит одну или несколько привязок, несовместимых с приложениями .Net Core. Пропуск...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">Значение, указанное для параметра --{0}, определяет путь к файлу "{1}", который не находится в каталоге проекта "{2}". Это может привести к тому, что файл не будет скомпилирован.</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.tr.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.tr.xlf
@@ -812,6 +812,11 @@ If you were trying to generate a client, this could be because the metadata docu
         <target state="translated">'{1}' adresindeki '{0}' uç noktası, .Net Core uygulamalarıyla uyumsuz bir veya daha fazla bağlama içerdiğinden atlanıyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">--{0} seçeneği ile belirtilen değer, '{2}' projesi dizini altında olmayan '{1}' dosya yoluna çözümlenir. Dosya derlenemeyebilir!</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hans.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hans.xlf
@@ -812,6 +812,11 @@ If you were trying to generate a client, this could be because the metadata docu
         <target state="translated">地址“{1}”处的终结点“{0}”包含一个或多个与 .Net Core 应用不兼容的绑定，正在跳过...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">通过 --{0} 选项指定的值解析为文件路径“{1}”，该文件路径不位于项目“{2}”的目录下。可能无法编译文件!</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hant.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hant.xlf
@@ -812,6 +812,11 @@ If you were trying to generate a client, this could be because the metadata docu
         <target state="translated">位於位址 '{1}' 的端點 '{0}' 包含一或多個與 .Net Core 應用程式不相容的繫結，將會跳過...</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrnOutOfSupportTargetFrameworkFormat">
+        <source>The target framework '{0}' is out of support and will not receive security updates in the future.</source>
+        <target state="new">The target framework '{0}' is out of support and will not receive security updates in the future.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrnSpecifiedFilePathNotUndeProjectDirFormat">
         <source>The value specified with the --{0} option resolves to the file path '{1}' which is not under the directory of the project '{2}'.  The file may not get compiled!</source>
         <target state="translated">使用 --{0} 選項來指定的值會解析為檔案路徑 '{1}'，但該路徑不在專案 '{2}' 的目錄下。檔案可能無法編譯!</target>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/array.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/array.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/arrayList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/arrayList.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/collection.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/collection.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/dictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/dictionary.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/hashTable.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/hashTable.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/hybridDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/hybridDictionary.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/linkedList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/linkedList.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/list.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/list.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/listDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/listDictionary.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/observableCollection.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/observableCollection.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/orderedDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/orderedDictionary.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/sortedDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/sortedDictionary.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/sortedList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/sortedList.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/sortedListNonGeneric.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/sortedListNonGeneric.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/mexParam.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/mexParam.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/noQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/noQuery.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/singleWsdlQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/singleWsdlQuery.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/wsdlQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/wsdlQuery.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/net60.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/net60.csproj
@@ -10,5 +10,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/net60.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/net60.csproj
@@ -10,8 +10,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
@@ -8,9 +8,6 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
   <ItemGroup>
     <Reference Condition="$(TargetFramework.StartsWith('net4'))" Include="System.ServiceModel">

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
@@ -13,7 +13,7 @@
     <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
   <ItemGroup>
-    <Reference Condition="'$(TargetFramework)' == 'net48'" Include="System.ServiceModel">
+    <Reference Condition="$(TargetFramework.StartsWith('net4'))" Include="System.ServiceModel">
       <HintPath>System.ServiceModel</HintPath>
     </Reference>
   </ItemGroup>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
@@ -4,14 +4,11 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-  </ItemGroup>
   <ItemGroup>
-    <Reference Condition="$(TargetFramework.StartsWith('net4'))" Include="System.ServiceModel">
-      <HintPath>System.ServiceModel</HintPath>
-    </Reference>
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/netstd20.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/netstd20.csproj
@@ -8,5 +8,6 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/TypeReuseClient.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/TypeReuseClient.csproj
@@ -13,8 +13,5 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/TypeReuseClient.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/TypeReuseClient.csproj
@@ -13,5 +13,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/net90.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/net90.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/tfm100.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/tfm100.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/tfm20.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/tfm20.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/tfm45.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/tfm45.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/tfmDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/tfmDefault.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmDefault/SvcutilBootstrapper/SvcutilBootstrapper.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmDefault/SvcutilBootstrapper/SvcutilBootstrapper.csproj
@@ -3,12 +3,19 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="dotnet-svcutil-lib">
       <HintPath>$resultPath$/TestResults/TFMBootstrap/tfmDefault/bin/Debug/DOTNET_VERSION/dotnet-svcutil-lib.dll</HintPath>
     </Reference>
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmDefault/bin/Debug/net9.0/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmDefault/bin/Debug/net9.0/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmDefault/bin/Debug/net9.0/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmDefault/tfmDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmDefault/tfmDefault.csproj
@@ -3,13 +3,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNet60/SvcutilBootstrapper/SvcutilBootstrapper.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNet60/SvcutilBootstrapper/SvcutilBootstrapper.csproj
@@ -3,12 +3,19 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="dotnet-svcutil-lib">
       <HintPath>$resultPath$/TestResults/TFMBootstrap/tfmNet60/bin/Debug/DOTNET_VERSION/dotnet-svcutil-lib.dll</HintPath>
     </Reference>
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmNet60/bin/Debug/net9.0/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmNet60/bin/Debug/net9.0/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmNet60/bin/Debug/net9.0/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNet60/tfmNet60.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNet60/tfmNet60.csproj
@@ -3,13 +3,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd20/SvcutilBootstrapper/SvcutilBootstrapper.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd20/SvcutilBootstrapper/SvcutilBootstrapper.csproj
@@ -3,12 +3,19 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="dotnet-svcutil-lib">
       <HintPath>$resultPath$/TestResults/TFMBootstrap/tfmNetstd20/bin/Debug/DOTNET_VERSION/dotnet-svcutil-lib.dll</HintPath>
     </Reference>
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmNetstd20/bin/Debug/net9.0/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmNetstd20/bin/Debug/net9.0/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmNetstd20/bin/Debug/net9.0/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd20/tfmNetstd20.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd20/tfmNetstd20.csproj
@@ -3,13 +3,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd21/SvcutilBootstrapper/SvcutilBootstrapper.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd21/SvcutilBootstrapper/SvcutilBootstrapper.csproj
@@ -3,12 +3,19 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="dotnet-svcutil-lib">
       <HintPath>$resultPath$/TestResults/TFMBootstrap/tfmNetstd21/bin/Debug/DOTNET_VERSION/dotnet-svcutil-lib.dll</HintPath>
     </Reference>
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmNetstd21/bin/Debug/net9.0/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmNetstd21/bin/Debug/net9.0/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$resultPath$/TestResults/TFMBootstrap/tfmNetstd21/bin/Debug/net9.0/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd21/tfmNetstd21.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd21/tfmNetstd21.csproj
@@ -3,13 +3,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalDefault/SvcutilBootstrapper/SvcutilBootstrapper.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalDefault/SvcutilBootstrapper/SvcutilBootstrapper.csproj
@@ -3,12 +3,19 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="dotnet-svcutil-lib">
       <HintPath>$USERPROFILE$/.dotnet/tools/.store/dotnet-svcutil/99.99.99/dotnet-svcutil/99.99.99/tools/DOTNET_VERSION/any/dotnet-svcutil-lib.dll</HintPath>
     </Reference>
+    <Content CopyToOutputDirectory="always" Include="$USERPROFILE$/.dotnet/tools/.store/dotnet-svcutil/99.99.99/dotnet-svcutil/99.99.99/tools/net8.0/any/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$USERPROFILE$/.dotnet/tools/.store/dotnet-svcutil/99.99.99/dotnet-svcutil/99.99.99/tools/net8.0/any/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$USERPROFILE$/.dotnet/tools/.store/dotnet-svcutil/99.99.99/dotnet-svcutil/99.99.99/tools/net8.0/any/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalDefault/tfmGlobalDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalDefault/tfmGlobalDefault.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalNetstd20/SvcutilBootstrapper/SvcutilBootstrapper.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalNetstd20/SvcutilBootstrapper/SvcutilBootstrapper.csproj
@@ -3,12 +3,19 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="dotnet-svcutil-lib">
       <HintPath>$USERPROFILE$/.dotnet/tools/.store/dotnet-svcutil/99.99.99/dotnet-svcutil/99.99.99/tools/DOTNET_VERSION/any/dotnet-svcutil-lib.dll</HintPath>
     </Reference>
+    <Content CopyToOutputDirectory="always" Include="$USERPROFILE$/.dotnet/tools/.store/dotnet-svcutil/99.99.99/dotnet-svcutil/99.99.99/tools/net8.0/any/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$USERPROFILE$/.dotnet/tools/.store/dotnet-svcutil/99.99.99/dotnet-svcutil/99.99.99/tools/net8.0/any/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$USERPROFILE$/.dotnet/tools/.store/dotnet-svcutil/99.99.99/dotnet-svcutil/99.99.99/tools/net8.0/any/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalNetstd20/tfmGlobalNetstd20.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalNetstd20/tfmGlobalNetstd20.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateRefLevels.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateRefLevels.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateRefLevelsFull.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateRefLevelsFull.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions_Folder_With_Spaces.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions_Folder_With_Spaces.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions_Folder_With_Spaces_Full.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions_Folder_With_Spaces_Full.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/CSServiceReference.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/CSServiceReference.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/CSServiceReferenceRoundtrip.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/CSServiceReferenceRoundtrip.csproj
@@ -8,14 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
-    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net6.0/**" Link="net6.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net8.0/**" Link="net8.0/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/net462/**" Link="net462/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Split PR #5519 - Part 2

**Description**:

1. Correctly resolve the target framework moniker string passed from the WCF CS Tool when it is netstandard.
2. Add WCF references based on the user's project target frameworks, accounting for .NET Framework, .NET Core, and .NET Standard, including both single-target and multi-target scenarios.
3. Remove WCF references older than version 4.10; retain only the three common WCF packages for the 8.* version, update the test baselines accordingly.