### PR TITLE
Make _RunWithCoreWcfService a variable again

### DIFF
--- a/azure-pipelines-arcade-PR.yml
+++ b/azure-pipelines-arcade-PR.yml
@@ -1,9 +1,3 @@
-parameters:
-- name: _RunWithCoreWcfService
-  displayName: Run tests using CoreWCF service
-  type: boolean
-  default: false
-
 # trigger ci builds for merged PRs into listed branches
 # Setting batch to true, triggers one build at a time.
 # if there is a push while a build in progress, it will wait,
@@ -37,7 +31,6 @@ variables:
     value: true
   - name: _RunAsInternal
     value: false
-  
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _RunAsPublic
       value: false
@@ -115,7 +108,7 @@ stages:
             Write-Host "##vso[task.setvariable variable=_serviceUri]wcfcoresrv23.westus3.cloudapp.azure.com/WcfService$(_WcfPRServiceId)"
 
           displayName: Update _updateService variable
-          condition: and(eq(variables._RunAsPublic, True), ne('${{ parameters._RunWithCoreWcfService }}', True))
+          condition: and(eq(variables._RunAsPublic, True), ne(variables._RunWithCoreWcfService, True))
 
         - ${{ if eq(variables._RunAsPublic, True) }}:
           - template: /eng/UpdatePRService.yml
@@ -138,7 +131,7 @@ stages:
             -projects $(Build.SourcesDirectory)/eng/SendToHelix.proj
             $(_TestArgs)
             /p:TestJob=Windows
-            /p:RunWithCoreWcfService=${{ parameters._RunWithCoreWcfService }}
+            /p:RunWithCoreWcfService=$($Env:_RunWithCoreWcfService)
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
           displayName: Windows - Run Helix Tests
           env:
@@ -187,7 +180,7 @@ stages:
               Write-Host "##vso[task.setvariable variable=_serviceUri]wcfcoresrv23.westus3.cloudapp.azure.com/WcfService$(_WcfPRServiceId)"
 
             displayName: Update _updateService variable
-            condition: and(eq(variables._RunAsPublic, True), ne('${{ parameters._RunWithCoreWcfService }}', True))
+            condition: and(eq(variables._RunAsPublic, True), ne(variables._RunWithCoreWcfService, True))
 
           - template: /eng/UpdatePRService.yml
             parameters:
@@ -207,7 +200,7 @@ stages:
               --projects $(Build.SourcesDirectory)/eng/SendToHelix.proj
               $(_TestArgs)
               /p:TestJob=Linux
-              /p:RunWithCoreWcfService=${{ parameters._RunWithCoreWcfService }}
+              /p:RunWithCoreWcfService=$($Env:_RunWithCoreWcfService)
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
             displayName: Linux - Run Helix Tests
             env:
@@ -254,7 +247,7 @@ stages:
               Write-Host "##vso[task.setvariable variable=_serviceUri]wcfcoresrv23.westus3.cloudapp.azure.com/WcfService$(_WcfPRServiceId)"
 
             displayName: Update _updateService variable
-            condition: and(eq(variables._RunAsPublic, True), ne('${{ parameters._RunWithCoreWcfService }}', True))
+            condition: and(eq(variables._RunAsPublic, True), ne(variables._RunWithCoreWcfService, True))
 
           - template: /eng/UpdatePRService.yml
             parameters:
@@ -274,7 +267,7 @@ stages:
               -projects $(Build.SourcesDirectory)/eng/SendToHelix.proj
               $(_TestArgs)
               /p:TestJob=MacOS
-              /p:RunWithCoreWcfService=${{ parameters._RunWithCoreWcfService }}
+              /p:RunWithCoreWcfService=$($Env:_RunWithCoreWcfService)
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
             displayName: MacOS - Run Helix Tests
             env:


### PR DESCRIPTION
Due to Azure DevOps not trusting my GitHub account to make changes to the yml for the corewcf ci run, the PR triggered build will fail due to not being able to use the access token. I've kicked off a manual build for the same commit which can use the access token (because Azure DevOps trusts my Azure authenticated account). You can verify this is doing the right thing by seeing that the step "Update 
_updateService variable" is skipped. This is the step which populates the service url and sets a variable telling a later step to update the test servers to be in line with the PR. We still have tests failing due to still ramping up CoreWCF for tests, so looking at this step is the easiest way to check if the _RunWithCoreWcfService variable is working as expected.  
https://dev.azure.com/dnceng-public/public/_build/results?buildId=822804&view=results