### PR TITLE
Handle current null-ref situation that can occur when Content-Type is present but Content-Length is 0.

### DIFF
--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpResponseMessageHelper.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpResponseMessageHelper.cs
@@ -297,7 +297,10 @@ namespace System.ServiceModel.Channels
             }
             finally
             {
-                inputStream.Dispose();
+                if (inputStream != null)
+                {
+                    inputStream.Dispose();
+                }
             }
         }
 


### PR DESCRIPTION
Simplest possible fix for null inputStream when ContentLength is 0.


Addresses #2999