### PR TITLE
Fix some exception handling

### DIFF
--- a/src/System.ServiceModel.NetTcp/src/System/ServiceModel/Channels/SocketConnection.cs
+++ b/src/System.ServiceModel.NetTcp/src/System/ServiceModel/Channels/SocketConnection.cs
@@ -969,17 +969,17 @@ namespace System.ServiceModel.Channels
                 }
             }
 
-            if (socketConnection == null)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                    new EndpointNotFoundException(SR.Format(SR.NoIPEndpointsFoundForHost, uri.Host)));
-            }
-
             if (lastException != null)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
                     SocketConnectionInitiator.ConvertConnectException(lastException, uri,
                     timeoutHelper.ElapsedTime(), lastException));
+            }
+
+            if (socketConnection == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    new EndpointNotFoundException(SR.Format(SR.NoIPEndpointsFoundForHost, uri.Host)));
             }
 
             return socketConnection;

--- a/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/AsyncResult.cs
+++ b/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/AsyncResult.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.Runtime.ExceptionServices;
 using System.Threading;
 
 namespace System.Runtime
@@ -348,7 +349,7 @@ namespace System.Runtime
 
             if (asyncResult._exception != null)
             {
-                throw Fx.Exception.AsError(asyncResult._exception);
+                ExceptionDispatchInfo.Capture(Fx.Exception.AsError(asyncResult._exception)).Throw();
             }
 
             return asyncResult;


### PR DESCRIPTION
Preserves the original stacktrace when AsyncResult is throwing stored exception
Fix order of null checks so that SocketConnection actually throws stored exception when failing to connect

Fixes #5697