### PR TITLE
Upgrade the version of the dotnet-svcutil-lib dependencies.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,15 +57,15 @@
   <PropertyGroup>
     <MicrosoftApplicationInsightsPackageVersion>2.20.0</MicrosoftApplicationInsightsPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>8.0.2</MicrosoftExtensionsDependencyModelPackageVersion>
-    <NuGetProjectModelPackageVersion>6.11.1</NuGetProjectModelPackageVersion>
-    <NuGetVersioningPackageVersion>6.11.1</NuGetVersioningPackageVersion>
+    <NuGetProjectModelPackageVersion>6.12.1</NuGetProjectModelPackageVersion>
+    <NuGetVersioningPackageVersion>6.12.1</NuGetVersioningPackageVersion>
     <SystemReflectionEmitPackageVersion>4.7.0</SystemReflectionEmitPackageVersion>
     <SystemReflectionEmitLightweightPackageVersion>4.7.0</SystemReflectionEmitLightweightPackageVersion>
     <SystemRuntimeLoaderPackageVersion>4.3.0</SystemRuntimeLoaderPackageVersion>
     <WCFClientPackageVersion Condition="'$(TargetFramework)' == 'net6.0'">6.2.0</WCFClientPackageVersion>
     <!-- Change net8.0, net9.0, net10.0, netstandard2.0, and net462 to 8.1.0 once it's released -->
-    <WCFClientPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">8.0.0</WCFClientPackageVersion>
-    <WCFClientPackageVersion Condition="'$(TargetFramework)' == 'net9.0'">8.0.0</WCFClientPackageVersion>
+    <WCFClientPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">8.1.1</WCFClientPackageVersion>
+    <WCFClientPackageVersion Condition="'$(TargetFramework)' == 'net9.0'">8.1.1</WCFClientPackageVersion>
     <WCFClientPackageVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.10.3</WCFClientPackageVersion>
     <WCFClientPackageVersion Condition="'$(TargetFramework)' == 'net462'">4.10.3</WCFClientPackageVersion>
     <SystemServiceModelNetTcpPackageVersion>$(WCFClientPackageVersion)</SystemServiceModelNetTcpPackageVersion>


### PR DESCRIPTION
NuGet.ProjectModel 6.11.1 has a transitive dependency on System.Formats.Asn1 6.0.0, which contains a critical security vulnerability.

CC: @HongGit , @mconnew 