### PR TITLE
Fix CancellationToken registration capturing the OperationContext

### DIFF
--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -1051,7 +1051,7 @@ namespace System.ServiceModel.Channels
 
                         try
                         {
-                            using (timeoutToken.Register(s_cancelCts, _httpSendCts))
+                            using (timeoutToken.UnsafeRegister(s_cancelCts, _httpSendCts))
                             {
                                 _httpResponseMessage = await _httpClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead, _httpSendCts.Token);
                             }

--- a/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/TimeoutHelper.cs
+++ b/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/TimeoutHelper.cs
@@ -214,7 +214,7 @@ namespace System.Runtime
             }
             else
             {
-                // http://msdn.microsoft.com/en-us/library/85bbbxt9(v=vs.110).aspx 
+                // http://msdn.microsoft.com/en-us/library/85bbbxt9(v=vs.110).aspx
                 // with exitContext was used in Desktop which is not supported in Net Native or CoreClr
                 return waitHandle.WaitOne(timeout);
             }
@@ -321,7 +321,7 @@ namespace System.Runtime
                     var token = tokenSource.Token;
 
                     // Clean up cache when Token is canceled
-                    token.Register(s_deregisterToken, Tuple.Create(targetTime, tokenSource));
+                    token.UnsafeRegister(s_deregisterToken, Tuple.Create(targetTime, tokenSource));
 
                     // set the result so other thread may observe the token, and return
                     tcs.TrySetResult(token);

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ProducerConsumerStream.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ProducerConsumerStream.cs
@@ -82,7 +82,7 @@ namespace System.ServiceModel.Channels
                 return 0;
             }
 
-            using (cancellationToken.Register(CancelAndDispose, this))
+            using (cancellationToken.UnsafeRegister(CancelAndDispose, this))
             {
                 Contract.Assert(!_buffer.Task.IsCompleted, "Buffer task should not already be completed");
                 Contract.Assert(_currentBuffer == WriteBufferWrapper.EmptyContainer, "The current buffer should be the EmptyContainer");
@@ -126,7 +126,7 @@ namespace System.ServiceModel.Channels
                 throw new ObjectDisposedException("ProducerConsumerStream");
             }
 
-            using (cancellationToken.Register(CancelAndDispose, this))
+            using (cancellationToken.UnsafeRegister(CancelAndDispose, this))
             {
                 while (count > 0)
                 {


### PR DESCRIPTION
We coalesce cancellation tokens to reduce timer registration and cancellation. We were capturing the execution context which was capturing the OperationContext which is stored in an AsyncLocal. By calling CancellationToken.UnsafeRegister, it prevents the execution context from being captured. This was showing up as a pseudo memory leak (not actually leaking memory, but holding on to it for an extended period).