### PR TITLE
escape path of dotnet-svcutil.xmlserializer.dll

### DIFF
--- a/src/svcutilcore/files/dotnet-svcutil.xmlserializer.targets
+++ b/src/svcutilcore/files/dotnet-svcutil.xmlserializer.targets
@@ -74,7 +74,7 @@
     <Delete Condition="Exists('$(_SerializerPdbIntermediateFolder)') == 'true'" Files="$(_SerializerPdbIntermediateFolder)" ContinueOnError="true" />
     <Delete Condition="Exists('$(_SerializerCsIntermediateFolder)') == 'true'" Files="$(_SerializerCsIntermediateFolder)" ContinueOnError="true" />
     <Message Text="Running SvcUtil Serialization Tool" Importance="normal" />
-    <Exec Command="dotnet $(MSBuildThisFileDirectory)..\lib\$(FrameworkVersion)\dotnet-svcutil.xmlserializer.dll $(IntermediateOutputPath)$(AssemblyName)$(TargetExt) --quiet --out:$(IntermediateOutputPath)$(_SerializationAssemblyName) --smreference:&quot;@(_ReferenceSMAssembly)&quot;" ContinueOnError="true" />
+    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)..\lib\$(FrameworkVersion)\dotnet-svcutil.xmlserializer.dll&quot; $(IntermediateOutputPath)$(AssemblyName)$(TargetExt) --quiet --out:$(IntermediateOutputPath)$(_SerializationAssemblyName) --smreference:&quot;@(_ReferenceSMAssembly)&quot;" ContinueOnError="true" />
     <Warning Condition="Exists('$(_SerializerCsIntermediateFolder)') != 'true'" Text="$(_SvcUtilWarningText)" />
     <Csc Condition="Exists('$(_SerializerCsIntermediateFolder)') == 'true'" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediateFolder)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediateFolder)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(_SerializationAssemblyDisabledWarnings)" />
     <Warning Condition="Exists('$(_SerializerDllIntermediateFolder)') != 'true' And Exists('$(_SerializerCsIntermediateFolder)') == 'true'" Text="$(_SvcUtilWarningText)" />


### PR DESCRIPTION
$(MSBuildThisFileDirectory) could include spaces. For example when the username include a space