### PR TITLE
Fix spelling of "references"

### DIFF
--- a/src/dotnet-svcutil/lib/src/SR.resx
+++ b/src/dotnet-svcutil/lib/src/SR.resx
@@ -220,7 +220,7 @@
     <value>Do not reference standard libraries. By default System.Runtime (mscorlib) and System.ServiceModel (WCF) libraries are referenced. (Short Form: -{0})</value>
   </data>
   <data name="HelpNoTypeReuseFormat" xml:space="preserve">
-    <value>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</value>
+    <value>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</value>
   </data>
   <data name="HelpExcludeTypeCodeGenerationFormat" xml:space="preserve">
     <value>A fully-qualified or assembly-qualified type name to exclude from referenced contract types. (Short Form: -{0})</value>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.cs.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.cs.xlf
@@ -563,7 +563,7 @@ Identifikátor dokumentu: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">Zakáže opakované používání typů z odkazů na projekt. Odkazy poskytnuté pomocí možnosti --{1} se budou brát v úvahu jen pro překlad typů kolekcí zadaných pomocí možnosti --{2}. (Krátký tvar: -{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.de.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.de.xlf
@@ -563,7 +563,7 @@ Dokumentbezeichner: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">Deaktivieren der Wiederverwendung von Typen aus Projektverweisen. Verweise, die mit der Option --{1} angegeben werden, werden nur für die Auflösung von Sammlungstypen berücksichtigt, die mit der Option --{2} angegeben wurden. (Kurzform: -{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.es.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.es.xlf
@@ -563,7 +563,7 @@ Identificador del documento: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">Deshabilite la reutilización de tipos de las referencias del proyecto. Las referencias proporcionadas con la opción --{1} solo se tendrán en cuenta para resolver los tipos de colección que se especifican con la opción --{2}. (Forma abreviada:-{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.fr.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.fr.xlf
@@ -563,7 +563,7 @@ Identificateur de document : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">Désactivez la réutilisation des types à partir des références de projet. Les références fournies avec l'option --{1} vont être prises en compte uniquement pour la résolution des types de collection spécifiés avec l'option --{2}. (Forme abrégée : -{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.it.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.it.xlf
@@ -563,7 +563,7 @@ Identificatore di documento: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">Disabilita il riutilizzo dei tipi dal riferimenti al progetto. I riferimenti specificati con l'opzione --{1} verranno presi in considerazione solo per risolvere i tipi di raccolta specificati con l'opzione --{2}. Forma breve: -{0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.ja.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.ja.xlf
@@ -563,7 +563,7 @@ Document Identifier: '{0}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">プロジェクト参照からの型の再利用を無効にします。--{1} オプションで指定された参照は、--{2} オプションで指定されたコレクション型を解決する場合にのみ考慮されます。(短い形式: -{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.ko.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.ko.xlf
@@ -563,7 +563,7 @@ Document Identifier: '{0}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">프로젝트 참조의 형식 재사용을 사용하지 않도록 설정합니다. --{1} 옵션과 함께 제공된 참조는 --{2} 옵션과 함께 지정된 컬렉션 형식 확인용으로만 간주됩니다(약식: -{0}).</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.pl.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.pl.xlf
@@ -563,7 +563,7 @@ Identyfikator dokumentu: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">Wyłącz ponowne używanie typów z odwołań projektu. Odwołania udostępnione za pomocą opcji --{1} będą uwzględniane tylko podczas rozpoznawania typów kolekcji określonych przy użyciu opcji --{2}. (Krótka forma: -{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.pt-BR.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.pt-BR.xlf
@@ -563,7 +563,7 @@ Identificador do Documento: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">Desabilite reutilizando tipos de referências de projeto. Referências fornecidas com a opção --{1} só serão consideradas para resolver os tipos de coleção especificados com a opção --{2}. (Forma abreviada: -{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.ru.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.ru.xlf
@@ -563,7 +563,7 @@ Document Identifier: '{0}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">Отключите повторное использование типов в ссылках проекта. Ссылки, указанные в параметре --{1}, могут использоваться только для разрешения типов коллекций, указанных в параметре --{2}. (Краткая форма: -{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.tr.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.tr.xlf
@@ -563,7 +563,7 @@ Belge Tanımlayıcısı: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">Proje başvurularından yeniden tür kullanılmasını devre dışı bırakın. --{1} seçeneği ile sağlanan başvurular yalnızca --{2} seçeneği ile belirtilen koleksiyon türlerini çözümlemek için kabul edilir. (Kısa Biçim: -{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hans.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hans.xlf
@@ -563,7 +563,7 @@ Document Identifier: '{0}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">禁止重新使用项目引用中的类型。通过 --{1} 选项提供的引用仅用于解析通过 --{2} 选项指定的集合类型。(缩写: -{0})</target>
         <note />
       </trans-unit>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hant.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hant.xlf
@@ -563,7 +563,7 @@ Document Identifier: '{0}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="HelpNoTypeReuseFormat">
-        <source>Disable reusing types from project refereces. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
+        <source>Disable reusing types from project references. References provided with the --{1} option will only be considered for resolving collection types specified with the --{2} option. (Short Form: -{0})</source>
         <target state="translated">禁止重複使用專案參考中的類型。使用 --{1} 選項來提供的參考只會用來解析使用 --{2} 選項來指定的集合類型。(簡短形式: -{0})</target>
         <note />
       </trans-unit>


### PR DESCRIPTION
Fixes spelling in the `dotnet-svcutil --help` output