### PR TITLE
Fix unnecessary package references which is breaking latest build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -81,8 +81,8 @@
     <SystemFormatsAsn1PackageVersion>8.0.1</SystemFormatsAsn1PackageVersion>
     <SystemTextJsonPackageVersion>8.0.5</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>8.0.0</SystemTextEncodingsWebPackageVersion>
-    <CoreWCFPrimitivesPackageVersion>1.6.0</CoreWCFPrimitivesPackageVersion>
-    <CoreWCFUnixDomainSocketPackageVersion>1.6.0</CoreWCFUnixDomainSocketPackageVersion>
-    <CoreWCFNetFramingBasePackageVersion>1.6.0</CoreWCFNetFramingBasePackageVersion>
+    <CoreWCFPrimitivesPackageVersion>1.7.0</CoreWCFPrimitivesPackageVersion>
+    <CoreWCFUnixDomainSocketPackageVersion>1.7.0</CoreWCFUnixDomainSocketPackageVersion>
+    <CoreWCFNetFramingBasePackageVersion>1.7.0</CoreWCFNetFramingBasePackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/UDS/Binding.UDS.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/UDS/Binding.UDS.IntegrationTests.csproj
@@ -10,11 +10,6 @@
     <PackageReference Include="CoreWCF.NetFramingBase" Version="$(CoreWCFNetFramingBasePackageVersion)" />
     <PackageReference Include="CoreWCF.UnixDomainSocket" Version="$(CoreWCFUnixDomainSocketPackageVersion)" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <!-- Temporary until CoreWCF is updated -->
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryPackageVersion)" />
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsPackageVersion)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(WcfInfrastructureCommonProj)" />


### PR DESCRIPTION
The latest pending arcade package version changes can't be applied due to explicit referencing some packages which are built into the runtime now, causing error NU1510.