### PR TITLE
[dotnet-svcutil] Add missing test baseline fix for a previous service typo fix

### DIFF
--- a/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
@@ -616,8 +616,8 @@ namespace Saml2IssuedToken_mex_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.TestFaultsResponse> TestFaultsAsync(Saml2IssuedToken_mex_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace Saml2IssuedToken_mex_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(Saml2IssuedToken_mex_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(Saml2IssuedToken_mex_NS.XmlMessageContractTestRequestWithMessageHeader request);
         

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
@@ -616,8 +616,8 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(BasicHttpsTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(BasicHttpsTransSecMessCredsUserName_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(BasicHttpsTransSecMessCredsUserName_NS.XmlMessageContractTestRequestWithMessageHeader request);
         

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
@@ -616,8 +616,8 @@ namespace BasicHttp_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttp_NS.TestFaultsResponse> TestFaultsAsync(BasicHttp_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace BasicHttp_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttp_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(BasicHttp_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttp_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(BasicHttp_NS.XmlMessageContractTestRequestWithMessageHeader request);
         

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
@@ -616,8 +616,8 @@ namespace BasicHttps_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttps_NS.TestFaultsResponse> TestFaultsAsync(BasicHttps_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace BasicHttps_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttps_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(BasicHttps_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttps_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(BasicHttps_NS.XmlMessageContractTestRequestWithMessageHeader request);
         

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttp_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttp_NS.TestFaultsResponse> TestFaultsAsync(NetHttp_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace NetHttp_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttp_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(NetHttp_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttp_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(NetHttp_NS.XmlMessageContractTestRequestWithMessageHeader request);
         

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttpWebSockets_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpWebSockets_NS.TestFaultsResponse> TestFaultsAsync(NetHttpWebSockets_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace NetHttpWebSockets_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpWebSockets_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(NetHttpWebSockets_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpWebSockets_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(NetHttpWebSockets_NS.XmlMessageContractTestRequestWithMessageHeader request);
         

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttps_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttps_NS.TestFaultsResponse> TestFaultsAsync(NetHttps_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace NetHttps_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttps_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(NetHttps_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttps_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(NetHttps_NS.XmlMessageContractTestRequestWithMessageHeader request);
         

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
@@ -616,8 +616,8 @@ namespace NetHttpsWebSockets_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpsWebSockets_NS.TestFaultsResponse> TestFaultsAsync(NetHttpsWebSockets_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace NetHttpsWebSockets_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpsWebSockets_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(NetHttpsWebSockets_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpsWebSockets_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(NetHttpsWebSockets_NS.XmlMessageContractTestRequestWithMessageHeader request);
         

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
@@ -616,8 +616,8 @@ namespace TcpTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(TcpTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace TcpTransSecMessCredsUserName_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(TcpTransSecMessCredsUserName_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(TcpTransSecMessCredsUserName_NS.XmlMessageContractTestRequestWithMessageHeader request);
         

--- a/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
@@ -616,8 +616,8 @@ namespace HttpsTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(HttpsTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -739,9 +739,9 @@ namespace HttpsTransSecMessCredsUserName_NS
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.XmlMessageContractTestResponse> EchoMessageResponseWithMessageHeaderAsync(HttpsTransSecMessCredsUserName_NS.XmlMessageContractTestRequest request);
         
-        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageResquestWithMess" +
-            "ageHeaderResponse")]
+        [System.ServiceModel.OperationContractAttribute(Action="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeader", ReplyAction="http://www.contoso.com/IXmlMessageContarctTestService/EchoMessageRequestWithMessa" +
+            "geHeaderResponse")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.XmlMessageContractTestResponse> EchoMessageRequestWithMessageHeaderAsync(HttpsTransSecMessCredsUserName_NS.XmlMessageContractTestRequestWithMessageHeader request);
         


### PR DESCRIPTION
A follow-up fix for PR #5788:
The WCF operation name EchoMessageResquestWithMessageHeader, which contains the typo "Resquest," is truncated in the generated client code, causing some places to be missed when attempting to fix it by finding and replacing the entire word.

Additionally, the reordering of two generated FaultContractAttribute attributes is included. Since the baseline file is tool-generated, the order of the attributes may vary if the service changes. However, for a fixed service, the order appears to be consistent, so this change has been applied here.