### PR TITLE
Fix: ReferencedTypeDoesNotMatch thrown on correct DataContract

### DIFF
--- a/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
+++ b/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
@@ -619,19 +619,31 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     await logger.WriteMessageAsync(Shared.Resources.ResolvingProjectReferences, logToUI: this.ToolContext <= OperationalContext.Global).ConfigureAwait(false);
 
                     var references = await this.Project.ResolveProjectReferencesAsync(ProjectDependency.IgnorableDependencies, logger, cancellationToken).ConfigureAwait(false);
+                    var projectDependencies = references.ToList();
 
+                    ToolConsole.WriteLine($"TypeReuseMode: {TypeReuseMode}");
                     if (this.TypeReuseMode == Svcutil.TypeReuseMode.All)
                     {
                         this.References.Clear();
-                        this.References.AddRange(references);
+                        this.References.AddRange(projectDependencies);
                     }
-                    else // Update operation: remove any reference no longer in the project!
+                    else 
                     {
+                        // Update operation: remove any reference no longer in the project!
                         for (int idx = this.References.Count - 1; idx >= 0; idx--)
                         {
-                            if (!references.Contains(this.References[idx]))
+                            if (!projectDependencies.Contains(this.References[idx]))
                             {
                                 this.References.RemoveAt(idx);
+                            }
+                        }
+
+                        // Add any new references that are not already in the list.
+                        foreach (var missingReference in projectDependencies)
+                        {
+                            if (!this.References.Contains(missingReference))
+                            {
+                                this.References.Add(missingReference);
                             }
                         }
                     }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/CodeExporter.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/CodeExporter.cs
@@ -560,7 +560,7 @@ namespace System.Runtime.Serialization
                     throw /*System.Runtime.Serialization.*/DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(string.Format(SRSerialization.TypeMustBeIXmlSerializable, DataContract.GetClrTypeFullName(type), DataContract.GetClrTypeFullName(Globals.TypeOfIXmlSerializable), dataContract.StableName.Name, dataContract.StableName.Namespace)));
                 }
                 DataContract referencedContract = _dataContractSet.GetDataContract(type);
-                if (referencedContract.Equals(dataContract))
+                if (referencedContract.StableName.Equals(dataContract.StableName))
                 {
                     typeReference = GetCodeTypeReference(type);
                     typeReference.UserData.Add(s_codeUserDataActualTypeKey, type);


### PR DESCRIPTION
This is the fix for the bug ticket Bug #5769

https://github.com/dotnet/wcf/issues/5769