### PR TITLE
Fix build scripts to accomodate build infrastructure changes

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/BuildCertUtil.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/BuildCertUtil.cmd
@@ -5,7 +5,7 @@ setlocal
 pushd %~dp0..\..\..\..\
 
 :buildsln
-set buildtool=eng\common\cibuild.cmd -warnAsError 0 -configuration Release -projects src\System.Private.ServiceModel\tools\CertificateGenerator\CertificateGenerator.sln /p:Sign=false
+set buildtool=eng\common\cibuild.cmd -warnAsError 0 -configuration Release -projects src\System.Private.ServiceModel\tools\CertificateGenerator\CertificateGenerator.sln /p:Sign=false /p:Publish=false
 echo %buildtool%
 call %buildtool%
 

--- a/src/System.Private.ServiceModel/tools/scripts/BuildWCFSelfHostedService.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/BuildWCFSelfHostedService.cmd
@@ -5,7 +5,7 @@ setlocal
 pushd %~dp0..\..\..\..\
 
 :buildsln
-set buildtool=eng\common\cibuild.cmd -warnAsError 0 -configuration Release -projects src\System.Private.ServiceModel\tools\SelfHostedWcfService\SelfHostedWCFService.sln /p:Sign=false
+set buildtool=eng\common\cibuild.cmd -warnAsError 0 -configuration Release -projects src\System.Private.ServiceModel\tools\SelfHostedWcfService\SelfHostedWCFService.sln /p:Sign=false /p:Publish=false
 echo %buildtool%
 call %buildtool%
 
@@ -15,3 +15,4 @@ endlocal
 
 :: Kill dotnet.exe process started by eng\common\cibuild.cmd which might remain running
 TASKKILL /F /IM dotnet.exe
+exit /b 0


### PR DESCRIPTION
Trying to run src\System.Private.ServiceModel\tools\scripts\StartWCFSelfHostedSvc.cmd currently fails due to changes in the build infrastructure that we sync from arcade. These changes fix starting the self hosted WCF service.