### PR TITLE
update test queues

### DIFF
--- a/eng/SendToHelix.proj
+++ b/eng/SendToHelix.proj
@@ -47,15 +47,14 @@
   <ItemGroup Condition="'$(TestJob)' == 'Windows' AND '$(RunAsInternal)'" >
     <HelixTargetQueue Include="windows.11.amd64.client" />
     <HelixTargetQueue Include="(Debian.12.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64" />
-    <HelixTargetQueue Include="(Mariner.2.0.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64" />
+    <HelixTargetQueue Include="(AzureLinux.3.0.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-helix-amd64" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestJob)' == 'Linux'" >
-    <HelixTargetQueue Include="SLES.15.Amd64.Open" />
     <HelixTargetQueue Include="(Fedora.41.Amd64.Open)ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-41-helix" /> 
     <HelixTargetQueue Include="Ubuntu.2204.Amd64.Open" />
     <HelixTargetQueue Include="(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64" />
-    <HelixTargetQueue Include="(Mariner.2.0.Amd64.Open)Ubuntu.2204.Amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64" />
+    <HelixTargetQueue Include="(AzureLinux.3.0.Amd64.Open)Ubuntu.2204.Amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-helix-amd64" />
     <HelixTargetQueue Include="(openSUSE.15.6.Amd64.Open)Ubuntu.2204.Amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:opensuse-15.6-helix-amd64" />
   </ItemGroup>
 


### PR DESCRIPTION
This brings test queues closer to dotnet/runtime
https://github.com/dotnet/runtime/blob/main/eng/pipelines/libraries/helix-queues-setup.yml

- runtime stop using SLES queue and uses OpenSuse docket image. It seems like WCF uses both now and that does not add much test coverage as the OpenSUSE is variant of commercially supported SLES. 
- Mariner 2 is EOL for a while and it was replaced by AzureLinux.3

runtime also moved from Ubuntu 22.04 as base queue to AzureLinux as the images are smaller, optimized for cloud and considered more secure. I did not want to make that change at the moment to decrease risk but perhaps something we can keep eyes when Ubuntu 22 gets closer to EOS. (April 2027) 

fixes https://github.com/dotnet/wcf/issues/5867