### PR TITLE
[dotnet-svcutil] Fix invalid ExcludeFromCodeCoverage codegen

### DIFF
--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Auto/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Auto/Reference.cs
@@ -655,7 +655,6 @@ namespace Auto_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="Auto_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace Auto_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : Auto_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/CollectionArray/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/CollectionArray/Reference.cs
@@ -655,7 +655,6 @@ namespace CollectionArray_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="CollectionArray_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace CollectionArray_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : CollectionArray_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/DataContractSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/DataContractSerializer/Reference.cs
@@ -655,7 +655,6 @@ namespace DataContractSerializer_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="DataContractSerializer_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace DataContractSerializer_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : DataContractSerializer_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/EnableDataBinding/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/EnableDataBinding/Reference.cs
@@ -888,7 +888,6 @@ namespace EnableDataBinding_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="EnableDataBinding_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -1021,7 +1020,6 @@ namespace EnableDataBinding_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : EnableDataBinding_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/ExcludeType/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/ExcludeType/Reference.cs
@@ -436,7 +436,6 @@ namespace ExcludeType_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Runtime.Serialization.DataContractAttribute(Name="HttpStatusCode", Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode : int
     {
         
@@ -803,7 +802,6 @@ namespace ExcludeType_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ExcludeType_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -936,7 +934,6 @@ namespace ExcludeType_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : ExcludeType_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Internal/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Internal/Reference.cs
@@ -655,7 +655,6 @@ namespace Internal_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="Internal_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     internal interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace Internal_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     internal interface IWcfProjectNServiceChannel : Internal_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/MessageContract/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/MessageContract/Reference.cs
@@ -655,7 +655,6 @@ namespace MessageContract_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="MessageContract_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -1158,7 +1157,6 @@ namespace MessageContract_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : MessageContract_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/NoStdLib/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/NoStdLib/Reference.cs
@@ -307,7 +307,6 @@ namespace NoStdLib_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Runtime.Serialization.DataContractAttribute(Name="DayOfWeek", Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek : int
     {
         
@@ -464,7 +463,6 @@ namespace NoStdLib_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Runtime.Serialization.DataContractAttribute(Name="HttpStatusCode", Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode : int
     {
         
@@ -831,7 +829,6 @@ namespace NoStdLib_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="NoStdLib_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -964,7 +961,6 @@ namespace NoStdLib_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : NoStdLib_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/None/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/None/Reference.cs
@@ -655,7 +655,6 @@ namespace None_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="None_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace None_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : None_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Sync/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/Sync/Reference.cs
@@ -655,7 +655,6 @@ namespace Sync_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="Sync_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -828,7 +827,6 @@ namespace Sync_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : Sync_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/SyncOnly/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/SyncOnly/Reference.cs
@@ -655,7 +655,6 @@ namespace SyncOnly_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="SyncOnly_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -786,7 +785,6 @@ namespace SyncOnly_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : SyncOnly_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
@@ -561,7 +561,6 @@ namespace XmlSerializer_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace XmlSerializer_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="XmlSerializer_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -1138,7 +1136,6 @@ namespace XmlSerializer_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -1789,7 +1786,6 @@ namespace XmlSerializer_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : XmlSerializer_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
@@ -561,7 +561,6 @@ namespace wrapped_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace wrapped_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="wrapped_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -1503,7 +1501,6 @@ namespace wrapped_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2319,7 +2316,6 @@ namespace wrapped_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : wrapped_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/Reference.cs
@@ -655,7 +655,6 @@ namespace array_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="array_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace array_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : array_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/Reference.cs
@@ -655,7 +655,6 @@ namespace arrayList_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="arrayList_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace arrayList_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : arrayList_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/Reference.cs
@@ -655,7 +655,6 @@ namespace collection_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="collection_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace collection_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : collection_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/Reference.cs
@@ -655,7 +655,6 @@ namespace dictionary_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="dictionary_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace dictionary_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : dictionary_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/Reference.cs
@@ -655,7 +655,6 @@ namespace hashTable_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="hashTable_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace hashTable_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : hashTable_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/Reference.cs
@@ -655,7 +655,6 @@ namespace hybridDictionary_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="hybridDictionary_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace hybridDictionary_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : hybridDictionary_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/Reference.cs
@@ -655,7 +655,6 @@ namespace linkedList_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="linkedList_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace linkedList_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : linkedList_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/Reference.cs
@@ -655,7 +655,6 @@ namespace list_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="list_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace list_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : list_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/Reference.cs
@@ -655,7 +655,6 @@ namespace listDictionary_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="listDictionary_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace listDictionary_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : listDictionary_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/Reference.cs
@@ -655,7 +655,6 @@ namespace observableCollection_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="observableCollection_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace observableCollection_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : observableCollection_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/Reference.cs
@@ -655,7 +655,6 @@ namespace orderedDictionary_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="orderedDictionary_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace orderedDictionary_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : orderedDictionary_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/Reference.cs
@@ -655,7 +655,6 @@ namespace sortedDictionary_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="sortedDictionary_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace sortedDictionary_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : sortedDictionary_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/Reference.cs
@@ -655,7 +655,6 @@ namespace sortedList_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="sortedList_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace sortedList_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : sortedList_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/Reference.cs
@@ -655,7 +655,6 @@ namespace sortedListNonGeneric_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="sortedListNonGeneric_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace sortedListNonGeneric_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : sortedListNonGeneric_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/ContractMemberNamedSystem/ContractMemberNamedSystem/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/ContractMemberNamedSystem/ContractMemberNamedSystem/Reference.cs
@@ -13,7 +13,6 @@ namespace ContractMemberNamedSystem_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(Namespace="http://Microsoft.ServiceModel.Samples", ConfigurationName="ContractMemberNamedSystem_NS.IService1")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1
     {
         
@@ -98,7 +97,6 @@ namespace ContractMemberNamedSystem_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1Channel : ContractMemberNamedSystem_NS.IService1, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/ContractTypeNamedReservedKeyword/ContractTypeNamedReservedKeyword/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/ContractTypeNamedReservedKeyword/ContractTypeNamedReservedKeyword/Reference.cs
@@ -166,7 +166,6 @@ namespace ContractTypeNamedReservedKeyword_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Runtime.Serialization.DataContractAttribute(Name="required", Namespace="http://schemas.datacontract.org/2004/07/WcfService1")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum @required : int
     {
         
@@ -179,7 +178,6 @@ namespace ContractTypeNamedReservedKeyword_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ContractTypeNamedReservedKeyword_NS.IService1")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1
     {
         
@@ -197,7 +195,6 @@ namespace ContractTypeNamedReservedKeyword_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1Channel : ContractTypeNamedReservedKeyword_NS.IService1, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/DuplexCallback/Duplex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/DuplexCallback/Duplex/Reference.cs
@@ -13,7 +13,6 @@ namespace Duplex_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="Duplex_NS.IWcfDuplexService", CallbackContract=typeof(Duplex_NS.IWcfDuplexServiceCallback))]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfDuplexService
     {
         
@@ -22,7 +21,6 @@ namespace Duplex_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfDuplexServiceCallback
     {
         
@@ -31,7 +29,6 @@ namespace Duplex_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfDuplexServiceChannel : Duplex_NS.IWcfDuplexService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
@@ -561,7 +561,6 @@ namespace Saml2IssuedToken_mex_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace Saml2IssuedToken_mex_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="Saml2IssuedToken_mex_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace Saml2IssuedToken_mex_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace Saml2IssuedToken_mex_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : Saml2IssuedToken_mex_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FullFramework/FullFramework/ServiceReference/Reference.cs
@@ -655,7 +655,6 @@ namespace ServiceReference
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ServiceReference.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace ServiceReference
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : ServiceReference.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/LanguageOption/CS/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/LanguageOption/CS/ServiceReference/Reference.cs
@@ -75,7 +75,6 @@ namespace ServiceReference
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ServiceReference.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace ServiceReference
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : ServiceReference.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/LanguageOption/VB/ServiceReference/Reference.vb
+++ b/src/dotnet-svcutil/lib/tests/Baselines/LanguageOption/VB/ServiceReference/Reference.vb
@@ -65,8 +65,7 @@ Namespace ServiceReference
     End Class
     
     <System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99"),  _
-     System.ServiceModel.ServiceContractAttribute(ConfigurationName:="ServiceReference.ITypeReuseSvc"),  _
-     System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()>  _
+     System.ServiceModel.ServiceContractAttribute(ConfigurationName:="ServiceReference.ITypeReuseSvc")>  _
     Public Interface ITypeReuseSvc
         
         <System.ServiceModel.OperationContractAttribute(Action:="http://tempuri.org/ITypeReuseSvc/GetData", ReplyAction:="http://tempuri.org/ITypeReuseSvc/GetDataResponse")>  _
@@ -76,8 +75,7 @@ Namespace ServiceReference
         Function GetDataUsingDataContractAsync(ByVal composite As ServiceReference.TypeReuseCompositeType) As System.Threading.Tasks.Task(Of ServiceReference.TypeReuseCompositeType)
     End Interface
     
-    <System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99"),  _
-     System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()>  _
+    <System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")>  _
     Public Interface ITypeReuseSvcChannel
         Inherits ServiceReference.ITypeReuseSvc, System.ServiceModel.IClientChannel
     End Interface

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/Reference.cs
@@ -52,7 +52,6 @@ namespace mexParam_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="mexParam_NS.IService1")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1
     {
         
@@ -64,7 +63,6 @@ namespace mexParam_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1Channel : mexParam_NS.IService1, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/Reference.cs
@@ -52,7 +52,6 @@ namespace noQuery_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="noQuery_NS.IService1")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1
     {
         
@@ -64,7 +63,6 @@ namespace noQuery_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1Channel : noQuery_NS.IService1, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/Reference.cs
@@ -52,7 +52,6 @@ namespace singleWsdlQuery_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="singleWsdlQuery_NS.IService1")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1
     {
         
@@ -64,7 +63,6 @@ namespace singleWsdlQuery_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1Channel : singleWsdlQuery_NS.IService1, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/Reference.cs
@@ -52,7 +52,6 @@ namespace wsdlQuery_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="wsdlQuery_NS.IService1")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1
     {
         
@@ -64,7 +63,6 @@ namespace wsdlQuery_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService1Channel : wsdlQuery_NS.IService1, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net48/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net48/ServiceReference/Reference.cs
@@ -75,7 +75,6 @@ namespace ServiceReference
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ServiceReference.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace ServiceReference
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : ServiceReference.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/ServiceReference/Reference.cs
@@ -75,7 +75,6 @@ namespace ServiceReference
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ServiceReference.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace ServiceReference
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : ServiceReference.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/ServiceReference/Reference.cs
@@ -75,7 +75,6 @@ namespace ServiceReference
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ServiceReference.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace ServiceReference
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : ServiceReference.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/netstd20/ServiceReference/Reference.cs
@@ -75,7 +75,6 @@ namespace ServiceReference
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ServiceReference.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace ServiceReference
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : ServiceReference.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/Reference.cs
@@ -52,7 +52,6 @@ namespace ServiceReference
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ServiceReference.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -64,7 +63,6 @@ namespace ServiceReference
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : ServiceReference.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAll/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAll/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocAll_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocAll_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocAll_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocAll_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAllRelative/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocAllRelative/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocAllRelative_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocAllRelative_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocAllRelative_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocAllRelative_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullAndWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullAndWildcard/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocFullAndWildcard_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocFullAndWildcard_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocFullAndWildcard_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocFullAndWildcard_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullPath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocFullPath/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocFullPath_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocFullPath_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocFullPath_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocFullPath_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativeAndWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativeAndWildcard/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocRelativeAndWildcard_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocRelativeAndWildcard_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocRelativeAndWildcard_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocRelativeAndWildcard_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativePath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocRelativePath/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocRelativePath_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocRelativePath_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocRelativePath_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocRelativePath_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlRelXsdWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlRelXsdWildcard/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocWsdlRelXsdWildcard_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocWsdlRelXsdWildcard_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocWsdlRelXsdWildcard_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocWsdlRelXsdWildcard_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcard/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcard/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocWsdlWildcard_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocWsdlWildcard_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocWsdlWildcard_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocWsdlWildcard_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcardRelative/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlWildcardRelative/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocWsdlWildcardRelative_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocWsdlWildcardRelative_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocWsdlWildcardRelative_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocWsdlWildcardRelative_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlXsdWildcardRelative/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultipleDocuments/multiDocWsdlXsdWildcardRelative/Reference.cs
@@ -655,7 +655,6 @@ namespace multiDocWsdlXsdWildcardRelative_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="multiDocWsdlXsdWildcardRelative_NS.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace multiDocWsdlXsdWildcardRelative_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : multiDocWsdlXsdWildcardRelative_NS.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/urlNamespace/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/urlNamespace/Reference.cs
@@ -665,7 +665,6 @@ namespace schemas.wcf.projectn.com.wcfnamespace
 
 [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
 [System.ServiceModel.ServiceContractAttribute(ConfigurationName="IWcfProjectNService")]
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
 public interface IWcfProjectNService
 {
     
@@ -798,7 +797,6 @@ public partial class ReplyBankingDataNotWrapped
 }
 
 [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
 public interface IWcfProjectNServiceChannel : IWcfProjectNService, System.ServiceModel.IClientChannel
 {
 }

--- a/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/wildcardNamespace/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/NamespaceParam/wildcardNamespace/Reference.cs
@@ -655,7 +655,6 @@ namespace TestNamespace
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="TestNamespace.IWcfProjectNService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNService
     {
         
@@ -788,7 +787,6 @@ namespace TestNamespace
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfProjectNServiceChannel : TestNamespace.IWcfProjectNService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/ReuseIXmlSerializableType/ReuseIXmlSerializableType/ServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/ReuseIXmlSerializableType/ReuseIXmlSerializableType/ServiceReference/Reference.cs
@@ -13,7 +13,6 @@ namespace ReuseIXmlSerializableType_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ReuseIXmlSerializableType_NS.IService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IService
     {
         
@@ -25,7 +24,6 @@ namespace ReuseIXmlSerializableType_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IServiceChannel : ReuseIXmlSerializableType_NS.IService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/Reference.cs
@@ -75,7 +75,6 @@ namespace net90_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="net90_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace net90_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : net90_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/Reference.cs
@@ -75,7 +75,6 @@ namespace tfm100_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfm100_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfm100_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfm100_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/Reference.cs
@@ -75,7 +75,6 @@ namespace tfm20_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfm20_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfm20_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfm20_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/Reference.cs
@@ -75,7 +75,6 @@ namespace tfm45_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfm45_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfm45_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfm45_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/Reference.cs
@@ -75,7 +75,6 @@ namespace tfmDefault_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfmDefault_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfmDefault_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfmDefault_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmDefault/Reference.cs
@@ -75,7 +75,6 @@ namespace tfmDefault_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfmDefault_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfmDefault_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfmDefault_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNet60/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNet60/Reference.cs
@@ -75,7 +75,6 @@ namespace tfmNet60_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfmNet60_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfmNet60_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfmNet60_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd20/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd20/Reference.cs
@@ -75,7 +75,6 @@ namespace tfmNetstd20_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfmNetstd20_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfmNetstd20_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfmNetstd20_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd21/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrap/tfmNetstd21/Reference.cs
@@ -75,7 +75,6 @@ namespace tfmNetstd21_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfmNetstd21_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfmNetstd21_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfmNetstd21_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalDefault/Reference.cs
@@ -75,7 +75,6 @@ namespace tfmGlobalDefault_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfmGlobalDefault_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfmGlobalDefault_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfmGlobalDefault_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalNetstd20/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFMBootstrapGlobal/tfmGlobalNetstd20/Reference.cs
@@ -75,7 +75,6 @@ namespace tfmGlobalNetstd20_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="tfmGlobalNetstd20_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace tfmGlobalNetstd20_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : tfmGlobalNetstd20_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping/Reference.cs
@@ -13,7 +13,6 @@ namespace UpdateNetPipeServiceRefBootstrapping
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateNetPipeServiceRefBootstrapping.IStreamedService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IStreamedService
     {
         
@@ -25,7 +24,6 @@ namespace UpdateNetPipeServiceRefBootstrapping
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IStreamedServiceChannel : UpdateNetPipeServiceRefBootstrapping.IStreamedService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault/Reference.cs
@@ -13,7 +13,6 @@ namespace UpdateNetPipeServiceRefDefault
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateNetPipeServiceRefDefault.IStreamedService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IStreamedService
     {
         
@@ -25,7 +24,6 @@ namespace UpdateNetPipeServiceRefDefault
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IStreamedServiceChannel : UpdateNetPipeServiceRefDefault.IStreamedService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefBootstrapping
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefBootstrapping.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefBootstrapping
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefBootstrapping.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefDefault
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefDefault.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefDefault
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefDefault.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevels/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevels/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevels
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptions.Level1.Level2.UpdateRefLevels.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevels
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptions.Level1.Level2.UpdateRefLevels.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevelsFull/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateServiceRefOptions/Level1/Level2/UpdateRefLevelsFull/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevelsFull
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptions.Level1.Level2.UpdateRefLevelsFull.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptions.Level1.Level2.UpdateRefLevelsFull
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptions.Level1.Level2.UpdateRefLevelsFull.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptionsDefault
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptionsDefault.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptionsDefault
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptionsDefault.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptionsExtraOptions
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptionsExtraOptions.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptionsExtraOptions
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptionsExtraOptions.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptionsExtraOptionsWarn
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptionsExtraOptionsWarn.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptionsExtraOptionsWarn
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptionsExtraOptionsWarn.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptionsFilePath
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptionsFilePath.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptionsFilePath
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptionsFilePath.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptionsFullPath
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptionsFullPath.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptionsFullPath
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptionsFullPath.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptionsRef
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptionsRef.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptionsRef
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptionsRef.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptionsRef2
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptionsRef2.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptionsRef2
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptionsRef2.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions Folder With Spaces/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions Folder With Spaces/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptions_Folder_With_Spaces.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptions_Folder_With_Spaces.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions Folder With Spaces Full/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions Folder With Spaces Full/Reference.cs
@@ -75,7 +75,6 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces_Full
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UpdateServiceRefOptions_Folder_With_Spaces_Full.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace UpdateServiceRefOptions_Folder_With_Spaces_Full
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : UpdateServiceRefOptions_Folder_With_Spaces_Full.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/Connected Services/CSServiceReference/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/Connected Services/CSServiceReference/Reference.cs
@@ -75,7 +75,6 @@ namespace ServiceReference1
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ServiceReference1.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace ServiceReference1
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : ServiceReference1.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/Connected Services/CSServiceReferenceRoundtrip/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/Connected Services/CSServiceReferenceRoundtrip/Reference.cs
@@ -75,7 +75,6 @@ namespace CSServiceReferenceRoundtrip_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="CSServiceReferenceRoundtrip_NS.ITypeReuseSvc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvc
     {
         
@@ -87,7 +86,6 @@ namespace CSServiceReferenceRoundtrip_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ITypeReuseSvcChannel : CSServiceReferenceRoundtrip_NS.ITypeReuseSvc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
@@ -561,7 +561,6 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="BasicHttpsTransSecMessCredsUserName_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : BasicHttpsTransSecMessCredsUserName_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
@@ -561,7 +561,6 @@ namespace BasicHttp_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace BasicHttp_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="BasicHttp_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace BasicHttp_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace BasicHttp_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : BasicHttp_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitDualNs/Reference.cs
@@ -128,7 +128,6 @@ namespace BasicHttpDocLitDualNs_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(Namespace="http://contoso.com/calc", ConfigurationName="BasicHttpDocLitDualNs_NS.ICalculatorDocLit")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorDocLit
     {
         
@@ -658,7 +657,6 @@ namespace BasicHttpDocLitDualNs_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorDocLitChannel : BasicHttpDocLitDualNs_NS.ICalculatorDocLit, System.ServiceModel.IClientChannel
     {
     }
@@ -859,7 +857,6 @@ namespace BasicHttpDocLitDualNs_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="BasicHttpDocLitDualNs_NS.IHelloWorldDocLit")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IHelloWorldDocLit
     {
         
@@ -1035,7 +1032,6 @@ namespace BasicHttpDocLitDualNs_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IHelloWorldDocLitChannel : BasicHttpDocLitDualNs_NS.IHelloWorldDocLit, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitSingleNs/Reference.cs
@@ -128,7 +128,6 @@ namespace BasicHttpDocLitSingleNs_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(Namespace="http://contoso.com/calc", ConfigurationName="BasicHttpDocLitSingleNs_NS.ICalculatorDocLit")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorDocLit
     {
         
@@ -658,7 +657,6 @@ namespace BasicHttpDocLitSingleNs_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorDocLitChannel : BasicHttpDocLitSingleNs_NS.ICalculatorDocLit, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncDualNs/Reference.cs
@@ -13,7 +13,6 @@ namespace BasicHttpRpcEncDualNs_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(Namespace="http://contoso.com/calc", ConfigurationName="BasicHttpRpcEncDualNs_NS.ICalculatorRpcEnc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorRpcEnc
     {
         
@@ -169,7 +168,6 @@ namespace BasicHttpRpcEncDualNs_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorRpcEncChannel : BasicHttpRpcEncDualNs_NS.ICalculatorRpcEnc, System.ServiceModel.IClientChannel
     {
     }
@@ -315,7 +313,6 @@ namespace BasicHttpRpcEncDualNs_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="BasicHttpRpcEncDualNs_NS.IHelloWorldRpcEnc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IHelloWorldRpcEnc
     {
         
@@ -329,7 +326,6 @@ namespace BasicHttpRpcEncDualNs_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IHelloWorldRpcEncChannel : BasicHttpRpcEncDualNs_NS.IHelloWorldRpcEnc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcEncSingleNs/Reference.cs
@@ -13,7 +13,6 @@ namespace BasicHttpRpcEncSingleNs_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(Namespace="http://contoso.com/calc", ConfigurationName="BasicHttpRpcEncSingleNs_NS.ICalculatorRpcEnc")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorRpcEnc
     {
         
@@ -169,7 +168,6 @@ namespace BasicHttpRpcEncSingleNs_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorRpcEncChannel : BasicHttpRpcEncSingleNs_NS.ICalculatorRpcEnc, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitDualNs/Reference.cs
@@ -128,7 +128,6 @@ namespace BasicHttpRpcLitDualNs_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(Namespace="http://contoso.com/calc", ConfigurationName="BasicHttpRpcLitDualNs_NS.ICalculatorRpcLit")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorRpcLit
     {
         
@@ -166,7 +165,6 @@ namespace BasicHttpRpcLitDualNs_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorRpcLitChannel : BasicHttpRpcLitDualNs_NS.ICalculatorRpcLit, System.ServiceModel.IClientChannel
     {
     }
@@ -312,7 +310,6 @@ namespace BasicHttpRpcLitDualNs_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="BasicHttpRpcLitDualNs_NS.IHelloWorldRpcLit")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IHelloWorldRpcLit
     {
         
@@ -326,7 +323,6 @@ namespace BasicHttpRpcLitDualNs_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IHelloWorldRpcLitChannel : BasicHttpRpcLitDualNs_NS.IHelloWorldRpcLit, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpRpcLitSingleNs/Reference.cs
@@ -128,7 +128,6 @@ namespace BasicHttpRpcLitSingleNs_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(Namespace="http://contoso.com/calc", ConfigurationName="BasicHttpRpcLitSingleNs_NS.ICalculatorRpcLit")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorRpcLit
     {
         
@@ -166,7 +165,6 @@ namespace BasicHttpRpcLitSingleNs_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface ICalculatorRpcLitChannel : BasicHttpRpcLitSingleNs_NS.ICalculatorRpcLit, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpSoap/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpSoap/Reference.cs
@@ -13,7 +13,6 @@ namespace BasicHttpSoap_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="BasicHttpSoap_NS.IWcfSoapService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfSoapService
     {
         
@@ -143,7 +142,6 @@ namespace BasicHttpSoap_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfSoapServiceChannel : BasicHttpSoap_NS.IWcfSoapService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp_4_4_0/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp_4_4_0/Reference.cs
@@ -13,7 +13,6 @@ namespace BasicHttp_4_4_0_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="BasicHttp_4_4_0_NS.IWcfService_4_4_0")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService_4_4_0
     {
         
@@ -190,7 +189,6 @@ namespace BasicHttp_4_4_0_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService_4_4_0Channel : BasicHttp_4_4_0_NS.IWcfService_4_4_0, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
@@ -561,7 +561,6 @@ namespace BasicHttps_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace BasicHttps_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="BasicHttps_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace BasicHttps_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace BasicHttps_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : BasicHttps_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
@@ -561,7 +561,6 @@ namespace NetHttp_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace NetHttp_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="NetHttp_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace NetHttp_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace NetHttp_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : NetHttp_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
@@ -561,7 +561,6 @@ namespace NetHttpWebSockets_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace NetHttpWebSockets_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="NetHttpWebSockets_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace NetHttpWebSockets_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace NetHttpWebSockets_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : NetHttpWebSockets_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
@@ -561,7 +561,6 @@ namespace NetHttps_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace NetHttps_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="NetHttps_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace NetHttps_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace NetHttps_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : NetHttps_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
@@ -561,7 +561,6 @@ namespace NetHttpsWebSockets_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace NetHttpsWebSockets_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="NetHttpsWebSockets_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace NetHttpsWebSockets_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace NetHttpsWebSockets_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : NetHttpsWebSockets_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
@@ -561,7 +561,6 @@ namespace TcpTransSecMessCredsUserName_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace TcpTransSecMessCredsUserName_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="TcpTransSecMessCredsUserName_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace TcpTransSecMessCredsUserName_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace TcpTransSecMessCredsUserName_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : TcpTransSecMessCredsUserName_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeReliableSessionSvc/ReliableSessionService/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeReliableSessionSvc/ReliableSessionService/Reference.cs
@@ -13,7 +13,6 @@ namespace ReliableSessionService_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="ReliableSessionService_NS.IWcfReliableService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfReliableService
     {
         
@@ -25,7 +24,6 @@ namespace ReliableSessionService_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfReliableServiceChannel : ReliableSessionService_NS.IWcfReliableService, System.ServiceModel.IClientChannel
     {
     }

--- a/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
@@ -561,7 +561,6 @@ namespace HttpsTransSecMessCredsUserName_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum DayOfWeek
     {
         
@@ -589,7 +588,6 @@ namespace HttpsTransSecMessCredsUserName_NS
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="HttpsTransSecMessCredsUserName_NS.IWcfService")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfService
     {
         
@@ -1345,7 +1343,6 @@ namespace HttpsTransSecMessCredsUserName_NS
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.datacontract.org/2004/07/System.Net")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public enum HttpStatusCode
     {
         
@@ -2309,7 +2306,6 @@ namespace HttpsTransSecMessCredsUserName_NS
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "99.99.99")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
     public interface IWcfServiceChannel : HttpsTransSecMessCredsUserName_NS.IWcfService, System.ServiceModel.IClientChannel
     {
     }


### PR DESCRIPTION
This PR is a follow-up to PR #5881 and continues the work for issue #5879.

It fixes dotnet-svcutil code generation to apply `ExcludeFromCodeCoverageAttribute `only to valid declarations when `GeneratedCodeAttribute `is present, preventing compiler errors caused by invalid attribute placement. Previously, `ExcludeFromCodeCoverageAttribute `was applied everywhere `GeneratedCodeAttribute `appeared.

In addition to the existing baseline comparison tests, the change was sanity-checked by compiling and running code generated from a few sample WCF services.

Cc: @mconnew 