### PR TITLE
Context agnostic async methods continuation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,6 +29,10 @@ csharp_new_line_between_query_expression_clauses = true
 # IDE1006: Naming Styles
 dotnet_diagnostic.IDE1006.severity = error
 
+# CA2007: Consider calling ConfigureAwait on the awaited task
+[src/System.ServiceModel*/**/*.cs]
+dotnet_diagnostic.CA2007.severity = error
+
 # Indentation preferences
 csharp_indent_block_contents = true
 csharp_indent_braces = false

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,6 +53,8 @@
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <EnableRunSettingsSupport Condition="'$(ContinuousIntegrationBuild)' != 'true'">true</EnableRunSettingsSupport>
+    <!-- Suppress CA2007 (ConfigureAwait) for test projects -->
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">

--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/ClientWebSocketTransportDuplexSessionChannel.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/ClientWebSocketTransportDuplexSessionChannel.cs
@@ -71,8 +71,8 @@ namespace System.ServiceModel.Channels
                 try
                 {
                     var clientWebSocket = new ClientWebSocket();
-                    await ConfigureClientWebSocketAsync(clientWebSocket, helper.RemainingTime());
-                    await clientWebSocket.ConnectAsync(Via, await helper.GetCancellationTokenAsync());
+                    await ConfigureClientWebSocketAsync(clientWebSocket, helper.RemainingTime()).ConfigureAwait(false);
+                    await clientWebSocket.ConnectAsync(Via, await helper.GetCancellationTokenAsync().ConfigureAwait(false)).ConfigureAwait(false);
                     ValidateWebSocketConnection(clientWebSocket);
                     WebSocket = clientWebSocket;
                 }
@@ -149,13 +149,13 @@ namespace System.ServiceModel.Channels
                     RemoteAddress,
                     Via,
                     channelParameterCollection,
-                    helper.RemainingTime());
+                    helper.RemainingTime()).ConfigureAwait(false);
 
             SecurityTokenContainer clientCertificateToken = null;
             if (_channelFactory is HttpsChannelFactory<IDuplexSessionChannel> httpsChannelFactory && httpsChannelFactory.RequireClientCertificate)
             {
-                SecurityTokenProvider certificateProvider = await httpsChannelFactory.CreateAndOpenCertificateTokenProviderAsync(RemoteAddress, Via, channelParameterCollection, helper.RemainingTime());
-                clientCertificateToken = await httpsChannelFactory.GetCertificateSecurityTokenAsync(certificateProvider, RemoteAddress, Via, channelParameterCollection, helper);
+                SecurityTokenProvider certificateProvider = await httpsChannelFactory.CreateAndOpenCertificateTokenProviderAsync(RemoteAddress, Via, channelParameterCollection, helper.RemainingTime()).ConfigureAwait(false);
+                clientCertificateToken = await httpsChannelFactory.GetCertificateSecurityTokenAsync(certificateProvider, RemoteAddress, Via, channelParameterCollection, helper).ConfigureAwait(false);
                 if (clientCertificateToken != null)
                 {
                     X509SecurityToken x509Token = (X509SecurityToken)clientCertificateToken.Token;
@@ -188,7 +188,7 @@ namespace System.ServiceModel.Channels
             }
 
             (NetworkCredential credential, TokenImpersonationLevel impersonationLevel, AuthenticationLevel authenticationLevel) =
-                await HttpChannelUtilities.GetCredentialAsync(_channelFactory.AuthenticationScheme, _webRequestTokenProvider, timeout);
+                await HttpChannelUtilities.GetCredentialAsync(_channelFactory.AuthenticationScheme, _webRequestTokenProvider, timeout).ConfigureAwait(false);
 
             if (_channelFactory.Proxy != null)
             {
@@ -200,7 +200,7 @@ namespace System.ServiceModel.Channels
                     authenticationLevel,
                     impersonationLevel,
                     _webRequestProxyTokenProvider,
-                    helper.RemainingTime());
+                    helper.RemainingTime()).ConfigureAwait(false);
             }
 
             if (credential == CredentialCache.DefaultCredentials || credential == null)

--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
@@ -75,18 +75,18 @@ namespace System.ServiceModel.Channels
             switch (authenticationScheme)
             {
                 case AuthenticationSchemes.Basic:
-                    var userNameCreds = await TransportSecurityHelpers.GetUserNameCredentialAsync(credentialProvider, timeout);
+                    var userNameCreds = await TransportSecurityHelpers.GetUserNameCredentialAsync(credentialProvider, timeout).ConfigureAwait(false);
                     return (userNameCreds, TokenImpersonationLevel.Delegation, AuthenticationLevel.None);
 
                 case AuthenticationSchemes.Digest:
-                    return await TransportSecurityHelpers.GetSspiCredentialAsync(credentialProvider, timeout);
+                    return await TransportSecurityHelpers.GetSspiCredentialAsync(credentialProvider, timeout).ConfigureAwait(false);
 
                 case AuthenticationSchemes.Negotiate:
-                    return await TransportSecurityHelpers.GetSspiCredentialAsync(credentialProvider, timeout);
+                    return await TransportSecurityHelpers.GetSspiCredentialAsync(credentialProvider, timeout).ConfigureAwait(false);
 
                 case AuthenticationSchemes.Ntlm:
                 case AuthenticationSchemes.IntegratedWindowsAuthentication: // IWA could use NTLM
-                    var result = await TransportSecurityHelpers.GetSspiCredentialAsync(credentialProvider, timeout);
+                    var result = await TransportSecurityHelpers.GetSspiCredentialAsync(credentialProvider, timeout).ConfigureAwait(false);
                     if (result.authenticationLevel == AuthenticationLevel.MutualAuthRequired)
                     {
                         throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(

--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpsChannelFactory.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpsChannelFactory.cs
@@ -146,7 +146,7 @@ namespace System.ServiceModel.Channels
 
         protected internal override async Task OnOpenAsync(TimeSpan timeout)
         {
-            await base.OnOpenAsync(timeout);
+            await base.OnOpenAsync(timeout).ConfigureAwait(false);
             OnOpenCore();
         }
 
@@ -159,7 +159,7 @@ namespace System.ServiceModel.Channels
 
             SecurityTokenProvider certificateProvider = TransportSecurityHelpers.GetCertificateTokenProvider(
                 SecurityTokenManager, target, via, Scheme, channelParameters);
-            await SecurityUtils.OpenTokenProviderIfRequiredAsync(certificateProvider, timeout);
+            await SecurityUtils.OpenTokenProviderIfRequiredAsync(certificateProvider, timeout).ConfigureAwait(false);
             return certificateProvider;
         }
 
@@ -171,7 +171,7 @@ namespace System.ServiceModel.Channels
             SecurityTokenProvider requestCertificateProvider;
             if (ManualAddressing && RequireClientCertificate)
             {
-                requestCertificateProvider = await CreateAndOpenCertificateTokenProviderAsync(to, via, channelParameters, timeoutHelper.RemainingTime());
+                requestCertificateProvider = await CreateAndOpenCertificateTokenProviderAsync(to, via, channelParameters, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             else
             {
@@ -180,7 +180,7 @@ namespace System.ServiceModel.Channels
 
             if (requestCertificateProvider != null)
             {
-                token = await requestCertificateProvider.GetTokenAsync(timeoutHelper.RemainingTime());
+                token = await requestCertificateProvider.GetTokenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             if (ManualAddressing && RequireClientCertificate)
@@ -322,7 +322,7 @@ namespace System.ServiceModel.Channels
             {
                 if (!ManualAddressing && Factory.RequireClientCertificate)
                 {
-                    _certificateProvider = await Factory.CreateAndOpenCertificateTokenProviderAsync(RemoteAddress, Via, ChannelParameters, timeout);
+                    _certificateProvider = await Factory.CreateAndOpenCertificateTokenProviderAsync(RemoteAddress, Via, ChannelParameters, timeout).ConfigureAwait(false);
                 }
             }
 
@@ -360,8 +360,8 @@ namespace System.ServiceModel.Channels
             internal protected override async Task OnOpenAsync(TimeSpan timeout)
             {
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                await CreateAndOpenTokenProviderAsync(timeoutHelper.RemainingTime());
-                await base.OnOpenAsync(timeoutHelper.RemainingTime());
+                await CreateAndOpenTokenProviderAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                await base.OnOpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             protected override void OnAbort()
@@ -390,8 +390,8 @@ namespace System.ServiceModel.Channels
 
             internal override async Task<HttpClient> GetHttpClientAsync(EndpointAddress to, Uri via, TimeoutHelper timeoutHelper)
             {
-                SecurityTokenContainer clientCertificateToken = await Factory.GetCertificateSecurityTokenAsync(_certificateProvider, to, via, ChannelParameters, timeoutHelper);
-                HttpClient httpClient = await GetHttpClientAsync(to, via, clientCertificateToken, timeoutHelper);
+                SecurityTokenContainer clientCertificateToken = await Factory.GetCertificateSecurityTokenAsync(_certificateProvider, to, via, ChannelParameters, timeoutHelper).ConfigureAwait(false);
+                HttpClient httpClient = await GetHttpClientAsync(to, via, clientCertificateToken, timeoutHelper).ConfigureAwait(false);
                 return httpClient;
             }
         }

--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/MessageContent.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/MessageContent.cs
@@ -188,7 +188,7 @@ namespace System.ServiceModel.Channels
                 var thisPtr = content as StreamedMessageContent;
                 try
                 {
-                    await _messageEncoder.WriteMessageAsync(thisPtr._message, thisPtr._stream);
+                    await _messageEncoder.WriteMessageAsync(thisPtr._message, thisPtr._stream).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -204,7 +204,7 @@ namespace System.ServiceModel.Channels
         {
             try
             {
-                await _messageEncoder.WriteMessageAsync(_message, new BufferedWriteStream(stream, _bufferManager));
+                await _messageEncoder.WriteMessageAsync(_message, new BufferedWriteStream(stream, _bufferManager)).ConfigureAwait(false);
             }
             finally
             {
@@ -255,7 +255,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 EnsureMessageEncoded();
-                await stream.WriteAsync(_buffer.Array, _buffer.Offset, _buffer.Count);
+                await stream.WriteAsync(_buffer.Array, _buffer.Offset, _buffer.Count).ConfigureAwait(false);
             }
             finally
             {

--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/SynchronizedMessageSource.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/SynchronizedMessageSource.cs
@@ -28,7 +28,7 @@ namespace System.ServiceModel.Channels
             // SemaphoreSlim doesn't accept timeouts > Int32.MaxValue.
             // Using TimeoutHelper.RemainingTime() would yield a value less than TimeSpan.MaxValue
             // and would result in the value Int32.MaxValue so we must use the original timeout specified.
-            if (!await _sourceLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)))
+            if (!await _sourceLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)).ConfigureAwait(false))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
                     new TimeoutException(SRP.Format(SRP.WaitForMessageTimedOut, timeout),
@@ -36,7 +36,7 @@ namespace System.ServiceModel.Channels
             }
             try
             {
-                return await _source.WaitForMessageAsync(timeoutHelper.RemainingTime());
+                return await _source.WaitForMessageAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             finally
             {
@@ -52,7 +52,7 @@ namespace System.ServiceModel.Channels
             // SemaphoreSlim doesn't accept timeouts > Int32.MaxValue.
             // Using TimeoutHelper.RemainingTime() would yield a value less than TimeSpan.MaxValue
             // and would result in the value Int32.MaxValue so we must use the original timeout specified.
-            if (!await _sourceLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)))
+            if (!await _sourceLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)).ConfigureAwait(false))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
                     new TimeoutException(SRP.Format(SRP.ReceiveTimedOut2, timeout),
@@ -61,7 +61,7 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                return await _source.ReceiveAsync(timeoutHelper.RemainingTime());
+                return await _source.ReceiveAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             finally
             {

--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/TransportDuplexSessionChannel.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/TransportDuplexSessionChannel.cs
@@ -81,7 +81,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                message = await MessageSource.ReceiveAsync(timeout);
+                message = await MessageSource.ReceiveAsync(timeout).ConfigureAwait(false);
                 OnReceiveMessage(message);
                 shouldFault = false;
                 return message;
@@ -145,7 +145,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                return (true, await ReceiveAsync(timeout));
+                return (true, await ReceiveAsync(timeout).ConfigureAwait(false));
             }
             catch(TimeoutException e)
             {
@@ -187,7 +187,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                bool success = await MessageSource.WaitForMessageAsync(timeout);
+                bool success = await MessageSource.WaitForMessageAsync(timeout).ConfigureAwait(false);
                 shouldFault = !success; // need to fault if we've timed out because we're now toast
                 return success;
             }
@@ -234,7 +234,7 @@ namespace System.ServiceModel.Channels
             // SemaphoreSlim doesn't accept timeouts > Int32.MaxValue.
             // Using TimeoutHelper.RemainingTime() would yield a value less than TimeSpan.MaxValue
             // and would result in the value Int32.MaxValue so we must use the original timeout specified.
-            if (!await SendLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)))
+            if (!await SendLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)).ConfigureAwait(false))
             {
                 if (WcfEventSource.Instance.CloseTimeoutIsEnabled())
                 {
@@ -261,7 +261,7 @@ namespace System.ServiceModel.Channels
                 bool shouldFault = true;
                 try
                 {
-                    await CloseOutputSessionCoreAsync(timeout);
+                    await CloseOutputSessionCoreAsync(timeout).ConfigureAwait(false);
                     OnOutputSessionClosed(ref timeoutHelper);
                     shouldFault = false;
                 }
@@ -351,12 +351,12 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnCloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await CloseOutputSessionAsync(timeoutHelper.RemainingTime());
+            await CloseOutputSessionAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             // close input session if necessary
             if (!_isInputSessionClosed)
             {
-                await EnsureInputClosedAsync(timeoutHelper.RemainingTime());
+                await EnsureInputClosedAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 OnInputSessionClosed();
             }
 
@@ -452,7 +452,7 @@ namespace System.ServiceModel.Channels
             // SemaphoreSlim doesn't accept timeouts > Int32.MaxValue.
             // Using TimeoutHelper.RemainingTime() would yield a value less than TimeSpan.MaxValue
             // and would result in the value Int32.MaxValue so we must use the original timeout specified.
-            if (!await SendLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)))
+            if (!await SendLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)).ConfigureAwait(false))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(
                                             SRP.Format(SRP.SendToViaTimedOut, Via, timeout),
@@ -501,7 +501,7 @@ namespace System.ServiceModel.Channels
                         tcs.TrySetResult(true);
                     }
 
-                    await tcs.Task;
+                    await tcs.Task.ConfigureAwait(false);
 
                     FinishWritingMessage();
 
@@ -611,7 +611,7 @@ namespace System.ServiceModel.Channels
 
         private async Task EnsureInputClosedAsync(TimeSpan timeout)
         {
-            Message message = await MessageSource.ReceiveAsync(timeout);
+            Message message = await MessageSource.ReceiveAsync(timeout).ConfigureAwait(false);
             if (message != null)
             {
                 using (message)

--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
@@ -113,10 +113,10 @@ namespace System.ServiceModel.Channels
             }
 
             var helper = new TimeoutHelper(timeout);
-            var cancelToken = await helper.GetCancellationTokenAsync();
+            var cancelToken = await helper.GetCancellationTokenAsync().ConfigureAwait(false);
             try
             {
-                await CloseOutputAsync(cancelToken);
+                await CloseOutputAsync(cancelToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -150,7 +150,7 @@ namespace System.ServiceModel.Channels
         {
             try
             {
-                await base.OnCloseAsync(timeout);
+                await base.OnCloseAsync(timeout).ConfigureAwait(false);
             }
             finally
             {
@@ -381,7 +381,7 @@ namespace System.ServiceModel.Channels
         {
             try
             {
-                await task;
+                await task.ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -397,7 +397,7 @@ namespace System.ServiceModel.Channels
         {
             try
             {
-                await task;
+                await task.ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -499,7 +499,7 @@ namespace System.ServiceModel.Channels
 
             public async Task<Message> ReceiveAsync(TimeSpan timeout)
             {
-                bool waitingResult = await _receiveTask.Task.AwaitWithTimeout(timeout);
+                bool waitingResult = await _receiveTask.Task.AwaitWithTimeout(timeout).ConfigureAwait(false);
                 ThrowOnPendingException(ref _pendingException);
 
                 if (!waitingResult)
@@ -527,7 +527,7 @@ namespace System.ServiceModel.Channels
             private async Task<Message> ReceiveAsyncInternal(TimeSpan timeout)
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                return await ReceiveAsync(timeout);
+                return await ReceiveAsync(timeout).ConfigureAwait(false);
             }
 
             private async Task ReadBufferedMessageAsync()
@@ -551,7 +551,7 @@ namespace System.ServiceModel.Channels
 
                             result = await _webSocket.ReceiveAsync(
                                                 new ArraySegment<byte>(internalBuffer, receivedByteCount, internalBuffer.Length - receivedByteCount),
-                                                CancellationToken.None);
+                                                CancellationToken.None).ConfigureAwait(false);
 
                             CheckCloseStatus(result);
                             endOfMessage = result.EndOfMessage;
@@ -645,10 +645,10 @@ namespace System.ServiceModel.Channels
 
             public async Task<bool> WaitForMessageAsync(TimeSpan timeout)
             {
-                bool waitingResult = await _receiveTask.Task.AwaitWithTimeout(timeout);
+                bool waitingResult = await _receiveTask.Task.AwaitWithTimeout(timeout).ConfigureAwait(false);
                 if (waitingResult)
                 {
-                    Message message = await ReceiveAsync(timeout);
+                    Message message = await ReceiveAsync(timeout).ConfigureAwait(false);
                     _pendingMessage = message;
                     return true;
                 }
@@ -708,7 +708,7 @@ namespace System.ServiceModel.Channels
                         if (_streamWaitTask != null)
                         {
                             //// Wait until the previous stream message finished.
-                            await _streamWaitTask.Task;
+                            await _streamWaitTask.Task.ConfigureAwait(false);
                         }
 
                         _streamWaitTask = new TaskCompletionSource<object>();
@@ -718,7 +718,7 @@ namespace System.ServiceModel.Channels
                     {
                         if (!_useStreaming)
                         {
-                            await ReadBufferedMessageAsync();
+                            await ReadBufferedMessageAsync().ConfigureAwait(false);
                         }
                         else
                         {
@@ -735,8 +735,8 @@ namespace System.ServiceModel.Channels
                                 {
                                     WebSocketReceiveResult result;
                                     TimeoutHelper helper = new TimeoutHelper(_asyncReceiveTimeout);
-                                    var cancelToken = await helper.GetCancellationTokenAsync();
-                                    result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(buffer, 0, _receiveBufferSize), cancelToken);
+                                    var cancelToken = await helper.GetCancellationTokenAsync().ConfigureAwait(false);
+                                    result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(buffer, 0, _receiveBufferSize), cancelToken).ConfigureAwait(false);
                                     CheckCloseStatus(result);
                                     _pendingMessage = PrepareMessage(result, buffer, result.Count);
 
@@ -1029,7 +1029,7 @@ namespace System.ServiceModel.Channels
                 WebSocketReceiveResult result;
                 try
                 {
-                    result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
+                    result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -1109,7 +1109,7 @@ namespace System.ServiceModel.Channels
 
                 try
                 {
-                    await _webSocket.SendAsync(new ArraySegment<byte>(buffer, offset, count), _outgoingMessageType, false, cancellationToken);
+                    await _webSocket.SendAsync(new ArraySegment<byte>(buffer, offset, count), _outgoingMessageType, false, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -1135,7 +1135,7 @@ namespace System.ServiceModel.Channels
             private async Task WriteAsyncInternal(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                await WriteAsync(buffer, offset, count, cancellationToken);
+                await WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             }
 
             public void WriteEndOfMessage()
@@ -1177,8 +1177,8 @@ namespace System.ServiceModel.Channels
                 var cancelTokenTask = timeoutHelper.GetCancellationTokenAsync();
                 try
                 {
-                    var cancelToken = await cancelTokenTask;
-                    await _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>(), 0, 0), _outgoingMessageType, true, cancelToken);
+                    var cancelToken = await cancelTokenTask.ConfigureAwait(false);
+                    await _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>(), 0, 0), _outgoingMessageType, true, cancelToken).ConfigureAwait(false);
 
                     if (WcfEventSource.Instance.WebSocketAsyncWriteStopIsEnabled())
                     {

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/Connection.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/Connection.cs
@@ -294,7 +294,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 SetReadTimeout(timeout);
-                return await Stream.ReadAsync(buffer);
+                return await Stream.ReadAsync(buffer).ConfigureAwait(false);
             }
             catch (IOException ioException)
             {
@@ -308,7 +308,7 @@ namespace System.ServiceModel.Channels
             {
                 _innerStream.Immediate = immediate;
                 SetWriteTimeout(timeout);
-                await Stream.WriteAsync(buffer);
+                await Stream.WriteAsync(buffer).ConfigureAwait(false);
             }
             catch (IOException ioException)
             {
@@ -322,7 +322,7 @@ namespace System.ServiceModel.Channels
             _innerStream.CloseTimeout = timeout;
             try
             {
-                await Stream.DisposeAsync();
+                await Stream.DisposeAsync().ConfigureAwait(false);
             }
             catch (IOException ioException)
             {

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/ConnectionPool.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/ConnectionPool.cs
@@ -51,7 +51,7 @@ namespace System.ServiceModel.Channels
 
         public async ValueTask<bool> CloseAsync(TimeSpan timeout)
         {
-            await ThisLock.WaitAsync();
+            await ThisLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 if (OpenCount <= 0)
@@ -63,7 +63,7 @@ namespace System.ServiceModel.Channels
 
                 if (OpenCount == 0)
                 {
-                    await OnCloseAsync(timeout);
+                    await OnCloseAsync(timeout).ConfigureAwait(false);
                     return true;
                 }
 
@@ -174,7 +174,7 @@ namespace System.ServiceModel.Channels
             {
                 try
                 {
-                    await pool.CloseAsync(timeoutHelper.RemainingTime());
+                    await pool.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
                 catch (CommunicationException)
                 {
@@ -337,7 +337,7 @@ namespace System.ServiceModel.Channels
                     }
                     try
                     {
-                        await Task.WhenAll(closeTasks);
+                        await Task.WhenAll(closeTasks).ConfigureAwait(false);
                     }
                     catch(AggregateException ae)
                     {
@@ -636,7 +636,7 @@ namespace System.ServiceModel.Channels
         {
             try
             {
-                await item.CloseAsync(timeout);
+                await item.CloseAsync(timeout).ConfigureAwait(false);
             }
             catch (Exception) { }
         }

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/ConnectionPoolHelper.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/ConnectionPoolHelper.cs
@@ -68,7 +68,7 @@ namespace System.ServiceModel.Channels
                     bool preambleSuccess = false;
                     try
                     {
-                        localUpgradedConnection = await AcceptPooledConnectionAsync(localRawConnection, timeoutHelper);
+                        localUpgradedConnection = await AcceptPooledConnectionAsync(localRawConnection, timeoutHelper).ConfigureAwait(false);
                         preambleSuccess = true;
                         break;
                     }
@@ -100,7 +100,7 @@ namespace System.ServiceModel.Channels
                 {
                     try
                     {
-                        localRawConnection = await _connectionInitiator.ConnectAsync(_via, connectTimeout);
+                        localRawConnection = await _connectionInitiator.ConnectAsync(_via, connectTimeout).ConfigureAwait(false);
                     }
                     catch (TimeoutException e)
                     {
@@ -109,7 +109,7 @@ namespace System.ServiceModel.Channels
                     }
 
                     _connectionInitiator = null;
-                    localUpgradedConnection = await AcceptPooledConnectionAsync(localRawConnection, timeoutHelper);
+                    localUpgradedConnection = await AcceptPooledConnectionAsync(localRawConnection, timeoutHelper).ConfigureAwait(false);
                     success = true;
                 }
                 finally

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/ConnectionPoolRegistry.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/ConnectionPoolRegistry.cs
@@ -76,10 +76,10 @@ namespace System.ServiceModel.Channels
 
         public async ValueTask ReleaseAsync(ConnectionPool pool, TimeSpan timeout)
         {
-            await ThisLock.WaitAsync();
+            await ThisLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                if (await pool.CloseAsync(timeout))
+                if (await pool.CloseAsync(timeout).ConfigureAwait(false))
                 {
                     List<ConnectionPool> registryEntry = _registry[pool.Name];
                     for (int i = 0; i < registryEntry.Count; i++)

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/ConnectionUtilities.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/ConnectionUtilities.cs
@@ -12,7 +12,7 @@ namespace System.ServiceModel.Channels
             bool success = false;
             try
             {
-                await connection.CloseAsync(timeout);
+                await connection.CloseAsync(timeout).ConfigureAwait(false);
                 success = true;
             }
             catch (TimeoutException)

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/NetFramingTransportChannelFactory.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/NetFramingTransportChannelFactory.cs
@@ -349,12 +349,12 @@ namespace System.ServiceModel.Channels
 
                 if (localConnectionPool != null)
                 {
-                    await ReleaseConnectionPoolAsync(localConnectionPool, timeoutHelper.RemainingTime());
+                    await ReleaseConnectionPoolAsync(localConnectionPool, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
 
                 if (localUpgrade != null)
                 {
-                    await Task.Factory.FromAsync(localUpgrade.BeginClose, localUpgrade.EndClose, timeoutHelper.RemainingTime(), null);
+                    await Task.Factory.FromAsync(localUpgrade.BeginClose, localUpgrade.EndClose, timeoutHelper.RemainingTime(), null).ConfigureAwait(false);
                 }
             }
         }

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/SessionConnectionReader.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/SessionConnectionReader.cs
@@ -112,14 +112,14 @@ namespace System.ServiceModel.Channels
                 {
                     // Using IConnection.ConnectionBufferSize as the length for the Memory<byte> as the EnvelopeBuffer is only used when the envelope (SOAP message) is larger
                     // than the connection buffer size and we limit the amount of data read from the connection at a time to ConnectionBufferSize bytes.
-                    bytesRead = await _connection.ReadAsync(new Memory<byte>(EnvelopeBuffer, EnvelopeOffset, _connection.ConnectionBufferSize), timeoutHelper.RemainingTime());
+                    bytesRead = await _connection.ReadAsync(new Memory<byte>(EnvelopeBuffer, EnvelopeOffset, _connection.ConnectionBufferSize), timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     HandleReadComplete(bytesRead, true);
                 }
                 else
                 {
                     // Using IConnection.ConnectionBufferSize as the length for the Memory<byte> as the leased buffer might be larger than ConnectionBufferSize and we
                     // limit the amount of data read from the connection at a time to ConnectionBufferSize bytes.
-                    bytesRead = await _connection.ReadAsync(new Memory<byte>(_buffer, 0, _connection.ConnectionBufferSize), timeoutHelper.RemainingTime());
+                    bytesRead = await _connection.ReadAsync(new Memory<byte>(_buffer, 0, _connection.ConnectionBufferSize), timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     HandleReadComplete(bytesRead, false);
                 }
             }
@@ -148,7 +148,7 @@ namespace System.ServiceModel.Channels
         {
             try
             {
-                Message message = await ReceiveAsync(timeout);
+                Message message = await ReceiveAsync(timeout).ConfigureAwait(false);
                 _pendingMessage = message;
                 return true;
             }

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
@@ -208,14 +208,14 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnOpenAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await SecurityUtilsEx.OpenTokenAuthenticatorIfRequiredAsync(ClientCertificateAuthenticator, timeoutHelper.RemainingTime());
+            await SecurityUtilsEx.OpenTokenAuthenticatorIfRequiredAsync(ClientCertificateAuthenticator, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             if (_serverTokenProvider != null)
             {
-                await SecurityUtils.OpenTokenProviderIfRequiredAsync(_serverTokenProvider, timeoutHelper.RemainingTime());
+                await SecurityUtils.OpenTokenProviderIfRequiredAsync(_serverTokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 SecurityToken token = _serverTokenProvider.GetTokenAsync(timeoutHelper.RemainingTime()).GetAwaiter().GetResult();
                 SetupServerCertificate(token);
-                await SecurityUtils.CloseTokenProviderIfRequiredAsync(_serverTokenProvider, timeoutHelper.RemainingTime());
+                await SecurityUtils.CloseTokenProviderIfRequiredAsync(_serverTokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 _serverTokenProvider = null;
             }
         }
@@ -328,21 +328,21 @@ namespace System.ServiceModel.Channels
         internal override async ValueTask OpenAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await base.OpenAsync(timeoutHelper.RemainingTime());
+            await base.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             if (_clientCertificateProvider != null)
             {
-                await SecurityUtils.OpenTokenProviderIfRequiredAsync(_clientCertificateProvider, timeoutHelper.RemainingTime());
-                _clientToken = (X509SecurityToken)await _clientCertificateProvider.GetTokenAsync(timeoutHelper.RemainingTime());
+                await SecurityUtils.OpenTokenProviderIfRequiredAsync(_clientCertificateProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                _clientToken = (X509SecurityToken)await _clientCertificateProvider.GetTokenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
         }
 
         internal override async ValueTask CloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await base.CloseAsync(timeoutHelper.RemainingTime());
+            await base.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             if (_clientCertificateProvider != null)
             {
-                await SecurityUtils.CloseTokenProviderIfRequiredAsync(_clientCertificateProvider, timeoutHelper.RemainingTime());
+                await SecurityUtils.CloseTokenProviderIfRequiredAsync(_clientCertificateProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
         }
 
@@ -367,7 +367,7 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                await sslStream.AuthenticateAsClientAsync(string.Empty, clientCertificates, _parent.SslProtocols, false);
+                await sslStream.AuthenticateAsClientAsync(string.Empty, clientCertificates, _parent.SslProtocols, false).ConfigureAwait(false);
             }
             catch (SecurityTokenValidationException tokenValidationException)
             {

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/StreamSecurityUpgradeInitiatorBase.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/StreamSecurityUpgradeInitiatorBase.cs
@@ -51,24 +51,24 @@ namespace System.ServiceModel.Channels
 
             if (!_isOpen)
             {
-                await OpenAsync(TimeSpan.Zero);
+                await OpenAsync(TimeSpan.Zero).ConfigureAwait(false);
             }
 
             Stream result;
-            (result, _remoteSecurity) = await OnInitiateUpgradeAsync(stream);
+            (result, _remoteSecurity) = await OnInitiateUpgradeAsync(stream).ConfigureAwait(false);
             _securityUpgraded = true;
             return result;
         }
 
         internal override async ValueTask OpenAsync(TimeSpan timeout)
         {
-            await base.OpenAsync(timeout);
+            await base.OpenAsync(timeout).ConfigureAwait(false);
             _isOpen = true;
         }
 
         internal override async ValueTask CloseAsync(TimeSpan timeout)
         {
-            await base.CloseAsync(timeout);
+            await base.CloseAsync(timeout).ConfigureAwait(false);
             _isOpen = false;
         }
 

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/StreamedFramingRequestChannel.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/StreamedFramingRequestChannel.cs
@@ -70,7 +70,7 @@ namespace System.ServiceModel.Channels
         internal async Task<(IConnection connection, SecurityMessageProperty remoteSecurity)> SendPreambleAsync(IConnection connection, TimeoutHelper timeoutHelper, ClientFramingDecoder decoder)
         {
             SecurityMessageProperty remoteSecurity = null;
-            await connection.WriteAsync(Preamble, true, timeoutHelper.RemainingTime());
+            await connection.WriteAsync(Preamble, true, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             if (_upgrade != null)
             {
@@ -78,10 +78,10 @@ namespace System.ServiceModel.Channels
                 StreamUpgradeInitiator upgradeInitiator = _upgrade.CreateUpgradeInitiator(RemoteAddress, Via);
 
                 bool upgradeInitiated;
-                (upgradeInitiated, connection)= await ConnectionUpgradeHelper.InitiateUpgradeAsync(upgradeInitiator, connection, decoder, this, timeoutHelper.RemainingTime());
+                (upgradeInitiated, connection)= await ConnectionUpgradeHelper.InitiateUpgradeAsync(upgradeInitiator, connection, decoder, this, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 if (!upgradeInitiated)
                 {
-                    await ConnectionUpgradeHelper.DecodeFramingFaultAsync(decoder, connection, Via, _messageEncoder.ContentType, timeoutHelper.RemainingTime());
+                    await ConnectionUpgradeHelper.DecodeFramingFaultAsync(decoder, connection, Via, _messageEncoder.ContentType, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
 
                 if (channelBindingProvider != null && channelBindingProvider.IsChannelBindingSupportEnabled)
@@ -90,16 +90,16 @@ namespace System.ServiceModel.Channels
                 }
 
                 remoteSecurity = StreamSecurityUpgradeInitiator.GetRemoteSecurity(upgradeInitiator);
-                await connection.WriteAsync(ClientSingletonEncoder.PreambleEndBytes, true, timeoutHelper.RemainingTime());
+                await connection.WriteAsync(ClientSingletonEncoder.PreambleEndBytes, true, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             byte[] ackBuffer = new byte[1];
-            int ackBytesRead = await connection.ReadAsync(ackBuffer, timeoutHelper.RemainingTime());
+            int ackBytesRead = await connection.ReadAsync(ackBuffer, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             if (!ConnectionUpgradeHelper.ValidatePreambleResponse(ackBuffer, ackBytesRead, decoder, Via))
             {
                 await ConnectionUpgradeHelper.DecodeFramingFaultAsync(decoder, connection, Via,
-                    _messageEncoder.ContentType, timeoutHelper.RemainingTime());
+                    _messageEncoder.ContentType, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             return (connection, remoteSecurity);
@@ -145,7 +145,7 @@ namespace System.ServiceModel.Channels
             protected override async Task<IConnection> AcceptPooledConnectionAsync(IConnection connection, TimeoutHelper timeoutHelper)
             {
                 Decoder = new ClientSingletonDecoder(0);
-                (connection, _remoteSecurity) = await _channel.SendPreambleAsync(connection, timeoutHelper, Decoder);
+                (connection, _remoteSecurity) = await _channel.SendPreambleAsync(connection, timeoutHelper, Decoder).ConfigureAwait(false);
                 return connection;
             }
 
@@ -220,10 +220,10 @@ namespace System.ServiceModel.Channels
                     {
                         try
                         {
-                            _connection = await _connectionPoolHelper.EstablishConnectionAsync(timeoutHelper.RemainingTime());
+                            _connection = await _connectionPoolHelper.EstablishConnectionAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
                             ChannelBindingUtility.TryAddToMessage(_channel._channelBindingToken, _message, false);
-                            await StreamingConnectionHelper.WriteMessageAsync(_message, _connection, true, _channel._settings, timeoutHelper);
+                            await StreamingConnectionHelper.WriteMessageAsync(_message, _connection, true, _channel._settings, timeoutHelper).ConfigureAwait(false);
                         }
                         catch (TimeoutException exception)
                         {
@@ -259,7 +259,7 @@ namespace System.ServiceModel.Channels
                     {
                         _connectionReader = new ClientSingletonConnectionReader(_connection, _connectionPoolHelper, _channel._settings);
                         _connectionReader.DoneSending(TimeSpan.Zero);
-                        Message message = await _connectionReader.ReceiveAsync(timeoutHelper);
+                        Message message = await _connectionReader.ReceiveAsync(timeoutHelper).ConfigureAwait(false);
                         if (message != null)
                         {
                             ChannelBindingUtility.TryAddToMessage(_channel._channelBindingToken, message, false);

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/SynchronizedMessageSource.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/SynchronizedMessageSource.cs
@@ -26,7 +26,7 @@ namespace System.ServiceModel.Channels
             // SemaphoreSlim doesn't accept timeouts > Int32.MaxValue.
             // Using TimeoutHelper.RemainingTime() would yield a value less than TimeSpan.MaxValue
             // and would result in the value Int32.MaxValue so we must use the original timeout specified.
-            if (!await _sourceLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)))
+            if (!await _sourceLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)).ConfigureAwait(false))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
                     new TimeoutException(SR.Format(SR.WaitForMessageTimedOut, timeout),
@@ -34,7 +34,7 @@ namespace System.ServiceModel.Channels
             }
             try
             {
-                return await _source.WaitForMessageAsync(timeoutHelper.RemainingTime());
+                return await _source.WaitForMessageAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             finally
             {
@@ -50,7 +50,7 @@ namespace System.ServiceModel.Channels
             // SemaphoreSlim doesn't accept timeouts > Int32.MaxValue.
             // Using TimeoutHelper.RemainingTime() would yield a value less than TimeSpan.MaxValue
             // and would result in the value Int32.MaxValue so we must use the original timeout specified.
-            if (!await _sourceLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)))
+            if (!await _sourceLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)).ConfigureAwait(false))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
                     new TimeoutException(SR.Format(SR.ReceiveTimedOut2, timeout),
@@ -59,7 +59,7 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                return await _source.ReceiveAsync(timeoutHelper.RemainingTime());
+                return await _source.ReceiveAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
             finally
             {

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/TransportDuplexSessionChannel.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/TransportDuplexSessionChannel.cs
@@ -84,7 +84,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                message = await MessageSource.ReceiveAsync(timeout);
+                message = await MessageSource.ReceiveAsync(timeout).ConfigureAwait(false);
                 OnReceiveMessage(message);
                 shouldFault = false;
                 return message;
@@ -147,7 +147,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                return (true, await ReceiveAsync(timeout));
+                return (true, await ReceiveAsync(timeout).ConfigureAwait(false));
             }
             catch(TimeoutException e)
             {
@@ -189,7 +189,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                bool success = await MessageSource.WaitForMessageAsync(timeout);
+                bool success = await MessageSource.WaitForMessageAsync(timeout).ConfigureAwait(false);
                 shouldFault = !success; // need to fault if we've timed out because we're now toast
                 return success;
             }
@@ -236,11 +236,11 @@ namespace System.ServiceModel.Channels
             ThrowIfFaulted();
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
 
-            // If timeout == TimeSpan.MaxValue, then we want to pass Timeout.Infinite as 
+            // If timeout == TimeSpan.MaxValue, then we want to pass Timeout.Infinite as
             // SemaphoreSlim doesn't accept timeouts > Int32.MaxValue.
             // Using TimeoutHelper.RemainingTime() would yield a value less than TimeSpan.MaxValue
             // and would result in the value Int32.MaxValue so we must use the original timeout specified.
-            if (!await SendLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)))
+            if (!await SendLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)).ConfigureAwait(false))
             {
                 if (WcfEventSource.Instance.CloseTimeoutIsEnabled())
                 {
@@ -267,7 +267,7 @@ namespace System.ServiceModel.Channels
                 bool shouldFault = true;
                 try
                 {
-                    await CloseOutputSessionCoreAsync(timeout);
+                    await CloseOutputSessionCoreAsync(timeout).ConfigureAwait(false);
                     OnOutputSessionClosed(ref timeoutHelper);
                     shouldFault = false;
                 }
@@ -302,12 +302,12 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnCloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await CloseOutputSessionAsync(timeoutHelper.RemainingTime());
+            await CloseOutputSessionAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             // close input session if necessary
             if (!_isInputSessionClosed)
             {
-                await EnsureInputClosedAsync(timeoutHelper.RemainingTime());
+                await EnsureInputClosedAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 OnInputSessionClosed();
             }
 
@@ -395,11 +395,11 @@ namespace System.ServiceModel.Channels
 
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
 
-            // If timeout == TimeSpan.MaxValue, then we want to pass Timeout.Infinite as 
+            // If timeout == TimeSpan.MaxValue, then we want to pass Timeout.Infinite as
             // SemaphoreSlim doesn't accept timeouts > Int32.MaxValue.
             // Using TimeoutHelper.RemainingTime() would yield a value less than TimeSpan.MaxValue
             // and would result in the value Int32.MaxValue so we must use the original timeout specified.
-            if (!await SendLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)))
+            if (!await SendLock.WaitAsync(TimeoutHelper.ToMilliseconds(timeout)).ConfigureAwait(false))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(
                                             SR.Format(SR.SendToViaTimedOut, Via, timeout),
@@ -423,7 +423,7 @@ namespace System.ServiceModel.Channels
 
                     if (IsStreamedOutput)
                     {
-                        await StartWritingStreamedMessage(message, timeoutHelper.RemainingTime());
+                        await StartWritingStreamedMessage(message, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     }
                     else
                     {
@@ -437,7 +437,7 @@ namespace System.ServiceModel.Channels
                                                         message,
                                                         messageData,
                                                         allowOutputBatching,
-                                                        timeoutHelper.RemainingTime());
+                                                        timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     }
 
                     success = true;
@@ -471,7 +471,7 @@ namespace System.ServiceModel.Channels
 
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
 
-            // If timeout == TimeSpan.MaxValue, then we want to pass Timeout.Infinite as 
+            // If timeout == TimeSpan.MaxValue, then we want to pass Timeout.Infinite as
             // SemaphoreSlim doesn't accept timeouts > Int32.MaxValue.
             // Using TimeoutHelper.RemainingTime() would yield a value less than TimeSpan.MaxValue
             // and would result in the value Int32.MaxValue so we must use the original timeout specified.
@@ -518,7 +518,7 @@ namespace System.ServiceModel.Channels
         // cleanup after the framing handshake has completed
         protected abstract void CompleteClose(TimeSpan timeout);
 
-        // must be called under sendLock 
+        // must be called under sendLock
         private void ThrowIfOutputSessionClosed()
         {
             if (_isOutputSessionClosed)
@@ -529,7 +529,7 @@ namespace System.ServiceModel.Channels
 
         private async Task EnsureInputClosedAsync(TimeSpan timeout)
         {
-            Message message = await MessageSource.ReceiveAsync(timeout);
+            Message message = await MessageSource.ReceiveAsync(timeout).ConfigureAwait(false);
             if (message != null)
             {
                 using (message)

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/TransportSecurityHelpers.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/TransportSecurityHelpers.cs
@@ -25,7 +25,7 @@ namespace System.ServiceModel.Channels
         // used by client WindowsStream security (from InitiateUpgrade)
         public static async ValueTask<(NetworkCredential credential, TokenImpersonationLevel impersonationLevel, bool allowNtlm)> GetSspiCredentialAsync(SecurityTokenProvider tokenProvider, TimeSpan timeout)
         {
-            var result = await GetSspiCredentialCoreAsync(tokenProvider, timeout);
+            var result = await GetSspiCredentialCoreAsync(tokenProvider, timeout).ConfigureAwait(false);
             return (result.credential, result.impersonationLevel, result.allowNtlm);
         }
 
@@ -41,7 +41,7 @@ namespace System.ServiceModel.Channels
 
             if (tokenProvider != null)
             {
-                SspiSecurityToken token = await WindowsStreamTransportSecurityHelpers.GetTokenAsync<SspiSecurityToken>(tokenProvider, timeout);
+                SspiSecurityToken token = await WindowsStreamTransportSecurityHelpers.GetTokenAsync<SspiSecurityToken>(tokenProvider, timeout).ConfigureAwait(false);
                 if (token != null)
                 {
                     result.extractGroupsForWindowsAccounts = token.ExtractGroupsForWindowsAccounts;
@@ -86,7 +86,7 @@ namespace System.ServiceModel.Channels
         private static async Task<T> GetTokenAsync<T>(SecurityTokenProvider tokenProvider, TimeSpan timeout)
             where T : SecurityToken
         {
-            SecurityToken result = await tokenProvider.GetTokenAsync(timeout);
+            SecurityToken result = await tokenProvider.GetTokenAsync(timeout).ConfigureAwait(false);
             if ((result != null) && !(result is T))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(

--- a/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/WindowsStreamSecurityUpgradeProvider.cs
+++ b/src/System.ServiceModel.NetFramingBase/src/System/ServiceModel/Channels/WindowsStreamSecurityUpgradeProvider.cs
@@ -130,17 +130,17 @@ namespace System.ServiceModel.Channels
             internal override async ValueTask OpenAsync(TimeSpan timeout)
             {
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                await base.OpenAsync(timeoutHelper.RemainingTime());
-                await SecurityUtils.OpenTokenProviderIfRequiredAsync(_clientTokenProvider, timeoutHelper.RemainingTime());
-                (_credential, _impersonationLevel, _allowNtlm) = await WindowsStreamTransportSecurityHelpers.GetSspiCredentialAsync(_clientTokenProvider, timeoutHelper.RemainingTime());
+                await base.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                await SecurityUtils.OpenTokenProviderIfRequiredAsync(_clientTokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                (_credential, _impersonationLevel, _allowNtlm) = await WindowsStreamTransportSecurityHelpers.GetSspiCredentialAsync(_clientTokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 return;
             }
 
             internal override async ValueTask CloseAsync(TimeSpan timeout)
             {
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                await base.CloseAsync(timeoutHelper.RemainingTime());
-                await SecurityUtils.CloseTokenProviderIfRequiredAsync(_clientTokenProvider, timeoutHelper.RemainingTime());
+                await base.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                await SecurityUtils.CloseTokenProviderIfRequiredAsync(_clientTokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             private static SecurityMessageProperty CreateServerSecurity(NegotiateStream negotiateStream)
@@ -179,7 +179,7 @@ namespace System.ServiceModel.Channels
                 // authenticate
                 try
                 {
-                    await negotiateStream.AuthenticateAsClientAsync(_credential, targetName, _parent.ProtectionLevel, _impersonationLevel);
+                    await negotiateStream.AuthenticateAsClientAsync(_credential, targetName, _parent.ProtectionLevel, _impersonationLevel).ConfigureAwait(false);
                 }
                 catch (AuthenticationException exception)
                 {

--- a/src/System.ServiceModel.NetNamedPipe/src/System/Runtime/BackoffTimeoutHelper.cs
+++ b/src/System.ServiceModel.NetNamedPipe/src/System/Runtime/BackoffTimeoutHelper.cs
@@ -63,7 +63,7 @@ namespace System.Runtime
 
         public async Task WaitAndBackoffAsync()
         {
-            await Task.Delay(WaitTimeWithDrift());
+            await Task.Delay(WaitTimeWithDrift()).ConfigureAwait(false);
             Backoff();
         }
 

--- a/src/System.ServiceModel.NetNamedPipe/src/System/ServiceModel/Channels/PipeConnection.cs
+++ b/src/System.ServiceModel.NetNamedPipe/src/System/ServiceModel/Channels/PipeConnection.cs
@@ -114,7 +114,7 @@ namespace System.ServiceModel.Channels
         public async ValueTask<int> ReadAsync(Memory<byte> buffer, TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            var cancellationToken = await timeoutHelper.GetCancellationTokenAsync();
+            var cancellationToken = await timeoutHelper.GetCancellationTokenAsync().ConfigureAwait(false);
 
             lock (_readLock)
             {
@@ -129,7 +129,7 @@ namespace System.ServiceModel.Channels
                     return 0;
                 }
 
-                int bytesRead = await _pipe.ReadAsync(buffer, cancellationToken);
+                int bytesRead = await _pipe.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
                 if (!buffer.IsEmpty && bytesRead == 0)
                 {
                     _isAtEOF = true;
@@ -161,7 +161,7 @@ namespace System.ServiceModel.Channels
         {
             ValidateBufferBounds(buffer);
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            var cancellationToken = await timeoutHelper.GetCancellationTokenAsync();
+            var cancellationToken = await timeoutHelper.GetCancellationTokenAsync().ConfigureAwait(false);
 
             lock (_writeLock)
             {
@@ -171,7 +171,7 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                await _pipe.WriteAsync(buffer, cancellationToken);
+                await _pipe.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
 
                 if (_closeState == CloseState.PipeClosed)
                 {
@@ -196,7 +196,7 @@ namespace System.ServiceModel.Channels
         {
             bool existingReadIsPending = false;
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            var cancellationToken = await timeoutHelper.GetCancellationTokenAsync();
+            var cancellationToken = await timeoutHelper.GetCancellationTokenAsync().ConfigureAwait(false);
 
             bool shouldClosePipe = false;
             try
@@ -261,7 +261,7 @@ namespace System.ServiceModel.Channels
                 {
                     try
                     {
-                        await WaitForWriteZero(writeValueTask, timeout, true);
+                        await WaitForWriteZero(writeValueTask, timeout, true).ConfigureAwait(false);
                     }
                     catch (TimeoutException e)
                     {
@@ -275,7 +275,7 @@ namespace System.ServiceModel.Channels
                 {
                     try
                     {
-                        await WaitForReadZero(readValueTask, timeout, true);
+                        await WaitForReadZero(readValueTask, timeout, true).ConfigureAwait(false);
                     }
                     catch (TimeoutException e)
                     {
@@ -285,7 +285,7 @@ namespace System.ServiceModel.Channels
                 }
                 else if (existingReadIsPending)
                 {
-                    if (!await _atEOFTask.Task.AwaitWithTimeout(timeoutHelper.RemainingTime()))
+                    if (!await _atEOFTask.Task.AwaitWithTimeout(timeoutHelper.RemainingTime()).ConfigureAwait(false))
                     {
                         throw DiagnosticUtility.ExceptionUtility.ThrowHelper(
                             new TimeoutException(SR.PipeShutdownReadError), ExceptionEventType);
@@ -303,10 +303,10 @@ namespace System.ServiceModel.Channels
                     readValueTask = StartReadZeroAsync(cancellationToken);
 
                     // wait for write to complete/fail
-                    await WaitForWriteZero(writeValueTask, timeout, false);
+                    await WaitForWriteZero(writeValueTask, timeout, false).ConfigureAwait(false);
 
                     // wait for read to complete/fail
-                    await WaitForReadZero(readValueTask, timeout, false);
+                    await WaitForReadZero(readValueTask, timeout, false).ConfigureAwait(false);
                 }
                 catch (PipeException e)
                 {
@@ -443,7 +443,7 @@ namespace System.ServiceModel.Channels
             int bytesRead = -1;
             try
             {
-                bytesRead = await readTask;
+                bytesRead = await readTask.ConfigureAwait(false);
                 success = true;
             }
             finally
@@ -478,7 +478,7 @@ namespace System.ServiceModel.Channels
         {
             try
             {
-                await writeTask;
+                await writeTask.ConfigureAwait(false);
             }
             catch(Exception)
             {

--- a/src/System.ServiceModel.NetNamedPipe/src/System/ServiceModel/Channels/PipeConnectionInitiator.cs
+++ b/src/System.ServiceModel.NetNamedPipe/src/System/ServiceModel/Channels/PipeConnectionInitiator.cs
@@ -47,7 +47,7 @@ namespace System.ServiceModel.Channels
                 connection =  TryConnect(remoteUri, resolvedAddress, backoffHelper);
                 if (connection == null)
                 {
-                    await backoffHelper.WaitAndBackoffAsync();
+                    await backoffHelper.WaitAndBackoffAsync().ConfigureAwait(false);
                     if (DiagnosticUtility.ShouldTraceInformation)
                     {
                         TraceUtility.TraceEvent(

--- a/src/System.ServiceModel.NetTcp/src/System/ServiceModel/Channels/DnsCache.cs
+++ b/src/System.ServiceModel.NetTcp/src/System/ServiceModel/Channels/DnsCache.cs
@@ -84,7 +84,7 @@ namespace System.ServiceModel.Channels
                 SocketException dnsException = null;
                 try
                 {
-                    hostAddresses = await LookupHostName(hostName);
+                    hostAddresses = await LookupHostName(hostName).ConfigureAwait(false);
                 }
                 catch (SocketException e)
                 {
@@ -110,7 +110,7 @@ namespace System.ServiceModel.Channels
 
         internal static async Task<IPAddress[]> LookupHostName(string hostName)
         {
-            return (await Dns.GetHostEntryAsync(hostName)).AddressList;
+            return (await Dns.GetHostEntryAsync(hostName).ConfigureAwait(false)).AddressList;
         }
 
         internal class DnsCacheEntry

--- a/src/System.ServiceModel.NetTcp/src/System/ServiceModel/Channels/SocketConnection.cs
+++ b/src/System.ServiceModel.NetTcp/src/System/ServiceModel/Channels/SocketConnection.cs
@@ -209,7 +209,7 @@ namespace System.ServiceModel.Channels
                     restoreFlow = false;
                     ExecutionContext.RestoreFlow();
                 }
-                bytesRead = await resultTask;
+                bytesRead = await resultTask.ConfigureAwait(false);
                 abortRead = false;
                 if (WcfEventSource.Instance.SocketReadStopIsEnabled())
                 {
@@ -295,7 +295,7 @@ namespace System.ServiceModel.Channels
                     ExecutionContext.RestoreFlow();
                 }
 
-                await resultTask;
+                await resultTask.ConfigureAwait(false);
                 abortWrite = false;
             }
             catch (SocketException socketException)
@@ -354,7 +354,7 @@ namespace System.ServiceModel.Channels
                 // host to send a FIN back. A pending read on a socket will complete returning zero bytes when a FIN
                 // packet is received.
                 byte[] dummy = Fx.AllocateByteArray(1);
-                int bytesRead = await ReadCoreAsync(dummy, _readFinTimeout, true);
+                int bytesRead = await ReadCoreAsync(dummy, _readFinTimeout, true).ConfigureAwait(false);
 
                 if (bytesRead > 0)
                 {
@@ -812,7 +812,7 @@ namespace System.ServiceModel.Channels
             {
                 AddressFamily addressFamily = address.AddressFamily;
                 socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp);
-                await socket.ConnectAsync(new IPEndPoint(address, port));
+                await socket.ConnectAsync(new IPEndPoint(address, port)).ConfigureAwait(false);
                 return new SocketConnection(socket, _bufferSize);
             }
             catch
@@ -894,7 +894,7 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                addresses = await DnsCache.ResolveAsync(uri);
+                addresses = await DnsCache.ResolveAsync(uri).ConfigureAwait(false);
             }
             catch (SocketException socketException)
             {
@@ -937,7 +937,7 @@ namespace System.ServiceModel.Channels
         public async ValueTask<IConnection> ConnectAsync(Uri uri, TimeSpan timeout)
         {
             int port = uri.Port;
-            IPAddress[] addresses = await GetIPAddressesAsync(uri);
+            IPAddress[] addresses = await GetIPAddressesAsync(uri).ConfigureAwait(false);
             IConnection socketConnection = null;
             SocketException lastException = null;
 
@@ -958,7 +958,7 @@ namespace System.ServiceModel.Channels
 
                 try
                 {
-                    socketConnection = await CreateConnectionAsync(addresses[i], port);
+                    socketConnection = await CreateConnectionAsync(addresses[i], port).ConfigureAwait(false);
                     lastException = null;
                     break;
                 }

--- a/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/ActionItem.cs
+++ b/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/ActionItem.cs
@@ -133,7 +133,7 @@ namespace System.Runtime
 
             private static async Task InvokeAsyncCallback(object state)
             {
-                await ((ActionItem)state).InvokeAsync();
+                await ((ActionItem)state).InvokeAsync().ConfigureAwait(false);
                 ((ActionItem)state)._isScheduled = false;
             }
         }
@@ -266,7 +266,7 @@ namespace System.Runtime
                     try
                     {
                         EtwDiagnosticTrace.ActivityId = _activityId;
-                        await _asyncCallback(_state);
+                        await _asyncCallback(_state).ConfigureAwait(false);
                     }
                     finally
                     {
@@ -290,7 +290,7 @@ namespace System.Runtime
                             }
                         }
 
-                        await _asyncCallback(_state);
+                        await _asyncCallback(_state).ConfigureAwait(false);
                     }
                     finally
                     {

--- a/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/AsyncLock.cs
+++ b/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/AsyncLock.cs
@@ -36,7 +36,7 @@ namespace System.Runtime
 
         private async Task<IAsyncDisposable> TakeLockCoreAsync(SemaphoreSlim currentSemaphore, SafeSemaphoreRelease safeSemaphoreRelease)
         {
-            await currentSemaphore.WaitAsync();
+            await currentSemaphore.WaitAsync().ConfigureAwait(false);
             return safeSemaphoreRelease;
         }
 
@@ -61,7 +61,7 @@ namespace System.Runtime
             _isDisposed = true;
             // Ensure the lock isn't held. If it is, wait for it to be released
             // before completing the dispose.
-            await _topLevelSemaphore.WaitAsync();
+            await _topLevelSemaphore.WaitAsync().ConfigureAwait(false);
             _topLevelSemaphore.Release();
             s_semaphorePool.Return(_topLevelSemaphore);
             _topLevelSemaphore = null;
@@ -101,7 +101,7 @@ namespace System.Runtime
 
             private async ValueTask DisposeCoreAsync()
             {
-                await _nextSemaphore.WaitAsync();
+                await _nextSemaphore.WaitAsync().ConfigureAwait(false);
                 _currentSemaphore.Release();
                 _nextSemaphore.Release();
                 s_semaphorePool.Return(_nextSemaphore);

--- a/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/InputQueue.cs
+++ b/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/InputQueue.cs
@@ -152,7 +152,7 @@ namespace System.Runtime
 
         public async Task<T> DequeueAsync(TimeSpan timeout)
         {
-            (bool success, T value) = await TryDequeueAsync(timeout);
+            (bool success, T value) = await TryDequeueAsync(timeout).ConfigureAwait(false);
 
             if (!success)
             {
@@ -205,7 +205,7 @@ namespace System.Runtime
 
             if (reader != null)
             {
-                return await reader.WaitAsync(timeout);
+                return await reader.WaitAsync(timeout).ConfigureAwait(false);
             }
             else
             {
@@ -1165,7 +1165,7 @@ namespace System.Runtime
 
             public async Task<(bool, T)> WaitAsync(TimeSpan timeout)
             {
-                if (!await _tcs.Task.AwaitWithTimeout(timeout))
+                if (!await _tcs.Task.AwaitWithTimeout(timeout).ConfigureAwait(false))
                 {
                     if (_inputQueue.RemoveReader(this))
                     {
@@ -1173,11 +1173,11 @@ namespace System.Runtime
                     }
                     else
                     {
-                        await _tcs.Task;
+                        await _tcs.Task.ConfigureAwait(false);
                     }
                 }
 
-                return (true, await _tcs.Task);
+                return (true, await _tcs.Task.ConfigureAwait(false));
             }
         }
 
@@ -1231,12 +1231,12 @@ namespace System.Runtime
 
             public async Task<bool> WaitAsync(TimeSpan timeout)
             {
-                if (!await _tcs.Task.AwaitWithTimeout(timeout))
+                if (!await _tcs.Task.AwaitWithTimeout(timeout).ConfigureAwait(false))
                 {
                     return false;
                 }
 
-                return await _tcs.Task;
+                return await _tcs.Task.ConfigureAwait(false);
             }
         }
     }

--- a/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/TaskHelpers.cs
+++ b/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/TaskHelpers.cs
@@ -17,7 +17,7 @@ namespace System.Runtime
         {
             try
             {
-                await task;
+                await task.ConfigureAwait(false);
             }
             catch
             {
@@ -25,7 +25,7 @@ namespace System.Runtime
             }
         }
 
-        // Helper method when implementing an APM wrapper around a Task based async method which returns a result. 
+        // Helper method when implementing an APM wrapper around a Task based async method which returns a result.
         // In the BeginMethod method, you would call use ToApm to wrap a call to MethodAsync:
         //     return MethodAsync(params).ToApm(callback, state);
         // In the EndMethod, you would use ToApmEnd<TResult> to ensure the correct exception handling
@@ -79,7 +79,7 @@ namespace System.Runtime
             return tcs.Task;
         }
 
-        // Helper method when implementing an APM wrapper around a Task based async method which returns a result. 
+        // Helper method when implementing an APM wrapper around a Task based async method which returns a result.
         // In the BeginMethod method, you would call use ToApm to wrap a call to MethodAsync:
         //     return MethodAsync(params).ToApm(callback, state);
         // In the EndMethod, you would use ToApmEnd to ensure the correct exception handling
@@ -225,13 +225,13 @@ namespace System.Runtime
 
             if (timeout == TimeSpan.MaxValue || timeout == Timeout.InfiniteTimeSpan)
             {
-                await task;
+                await task.ConfigureAwait(false);
                 return true;
             }
 
             using (CancellationTokenSource cts = new CancellationTokenSource())
             {
-                var completedTask = await Task.WhenAny(task, Task.Delay(timeout, cts.Token));
+                var completedTask = await Task.WhenAny(task, Task.Delay(timeout, cts.Token)).ConfigureAwait(false);
                 if (completedTask == task)
                 {
                     cts.Cancel();

--- a/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/TimeoutHelper.cs
+++ b/src/System.ServiceModel.Primitives/src/Internals/System/Runtime/TimeoutHelper.cs
@@ -48,7 +48,7 @@ namespace System.Runtime
                 }
                 else if (timeout > TimeSpan.Zero)
                 {
-                    _cancellationToken = await TimeoutTokenSource.FromTimeoutAsync((int)timeout.TotalMilliseconds);
+                    _cancellationToken = await TimeoutTokenSource.FromTimeoutAsync((int)timeout.TotalMilliseconds).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/System.ServiceModel.Primitives/src/Internals/System/Xml/XmlMtomWriter.cs
+++ b/src/System.ServiceModel.Primitives/src/Internals/System/Xml/XmlMtomWriter.cs
@@ -210,9 +210,9 @@ namespace System.Xml
 
         public override async Task WriteStartElementAsync(string prefix, string localName, string ns)
         {
-            await WriteBase64InlineIfPresentAsync();
+            await WriteBase64InlineIfPresentAsync().ConfigureAwait(false);
             ThrowIfElementIsXOPInclude(prefix, localName, ns);
-            await Writer.WriteStartElementAsync(prefix, localName, ns);
+            await Writer.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(false);
             _depth++;
         }
 
@@ -254,10 +254,10 @@ namespace System.Xml
 
         public override async Task WriteEndElementAsync()
         {
-            await WriteXOPIncludeAsync();
-            await Writer.WriteEndElementAsync();
+            await WriteXOPIncludeAsync().ConfigureAwait(false);
+            await Writer.WriteEndElementAsync().ConfigureAwait(false);
             _depth--;
-            await WriteXOPBinaryPartsAsync();
+            await WriteXOPBinaryPartsAsync().ConfigureAwait(false);
         }
 
         public override void WriteFullEndElement()
@@ -389,11 +389,11 @@ namespace System.Xml
             {
                 if (data.type == MtomBinaryDataType.Provider)
                 {
-                    await Writer.WriteValueAsync(data.provider);
+                    await Writer.WriteValueAsync(data.provider).ConfigureAwait(false);
                 }
                 else
                 {
-                    await Writer.WriteBase64Async(data.chunk, 0, data.chunk.Length);
+                    await Writer.WriteBase64Async(data.chunk, 0, data.chunk.Length).ConfigureAwait(false);
                 }
             }
             _sizeOfBufferedBinaryData = 0;
@@ -464,7 +464,7 @@ namespace System.Xml
             }
 
             if (inline)
-                await WriteBase64InlineAsync();
+                await WriteBase64InlineAsync().ConfigureAwait(false);
             else
             {
                 if (_mimeParts == null)
@@ -476,11 +476,11 @@ namespace System.Xml
                 _totalSizeOfMimeParts += ValidateSizeOfMessage(_maxSizeInBytes, _totalSizeOfMimeParts, mimePart.sizeInBytes);
                 _totalSizeOfMimeParts += ValidateSizeOfMessage(_maxSizeInBytes, _totalSizeOfMimeParts, _mimeWriter.GetBoundarySize());
 
-                await Writer.WriteStartElementAsync(MtomGlobals.XopIncludePrefix, MtomGlobals.XopIncludeLocalName, MtomGlobals.XopIncludeNamespace);
+                await Writer.WriteStartElementAsync(MtomGlobals.XopIncludePrefix, MtomGlobals.XopIncludeLocalName, MtomGlobals.XopIncludeNamespace).ConfigureAwait(false);
                 Writer.WriteStartAttribute(MtomGlobals.XopIncludeHrefLocalName, MtomGlobals.XopIncludeHrefNamespace);
                 Writer.WriteString(string.Format(CultureInfo.InvariantCulture, "{0}{1}", MimeGlobals.ContentIDScheme, _contentID));
                 Writer.WriteEndAttribute();
-                await Writer.WriteEndElementAsync();
+                await Writer.WriteEndElementAsync().ConfigureAwait(false);
                 _binaryDataChunks = null;
                 _sizeOfBufferedBinaryData = 0;
                 _contentType = null;
@@ -518,7 +518,7 @@ namespace System.Xml
                                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SRP.XmlInvalidStream));
 
                             stream.CopyTo(s, bufferSize);
-                            
+
                             data.provider.ReleaseStream(stream);
                         }
                         else
@@ -538,14 +538,14 @@ namespace System.Xml
                 return;
 
             if (Writer.WriteState != WriteState.Closed)
-                await Writer.FlushAsync();
+                await Writer.FlushAsync().ConfigureAwait(false);
 
             if (_mimeParts != null)
             {
                 foreach (MimePart part in _mimeParts)
                 {
-                    await WriteMimeHeadersAsync(part.contentID, part.contentType, part.contentTransferEncoding);
-                    Stream s = await _mimeWriter.GetContentStreamAsync();
+                    await WriteMimeHeadersAsync(part.contentID, part.contentType, part.contentTransferEncoding).ConfigureAwait(false);
+                    Stream s = await _mimeWriter.GetContentStreamAsync().ConfigureAwait(false);
                     int bufferSize = 65536;
                     Stream stream = null;
                     foreach (MtomBinaryData data in part.binaryData)
@@ -556,19 +556,19 @@ namespace System.Xml
                             if (stream == null)
                                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SRP.XmlInvalidStream));
 
-                            await stream.CopyToAsync(s, bufferSize);
+                            await stream.CopyToAsync(s, bufferSize).ConfigureAwait(false);
 
                             data.provider.ReleaseStream(stream);
                         }
                         else
                         {
-                            await s.WriteAsync(data.chunk, 0, data.chunk.Length);
+                            await s.WriteAsync(data.chunk, 0, data.chunk.Length).ConfigureAwait(false);
                         }
                     }
                 }
                 _mimeParts.Clear();
             }
-            await _mimeWriter.CloseAsync();
+            await _mimeWriter.CloseAsync().ConfigureAwait(false);
         }
 
         private void WriteMimeHeaders(string contentID, string contentType, string contentTransferEncoding)
@@ -584,7 +584,7 @@ namespace System.Xml
 
         private async Task WriteMimeHeadersAsync(string contentID, string contentType, string contentTransferEncoding)
         {
-            await _mimeWriter.StartPartAsync();
+            await _mimeWriter.StartPartAsync().ConfigureAwait(false);
             if (contentID != null)
                 _mimeWriter.WriteHeader(MimeGlobals.ContentIDHeader, string.Format(CultureInfo.InvariantCulture, "<{0}>", contentID));
             if (contentTransferEncoding != null)
@@ -1247,7 +1247,7 @@ namespace System.Xml
 
             if (contentStream != null)
             {
-                await contentStream.FlushAsync();
+                await contentStream.FlushAsync().ConfigureAwait(false);
                 contentStream = null;
             }
 
@@ -1294,7 +1294,7 @@ namespace System.Xml
 
             if (contentStream != null)
             {
-                await contentStream.FlushAsync();
+                await contentStream.FlushAsync().ConfigureAwait(false);
                 contentStream = null;
             }
 
@@ -1302,7 +1302,7 @@ namespace System.Xml
             bufferedWrite.Write(MimeGlobals.DASHDASH);
             bufferedWrite.Write(MimeGlobals.CRLF);
 
-            await FlushAsync();
+            await FlushAsync().ConfigureAwait(false);
         }
 
         private void Flush()
@@ -1318,7 +1318,7 @@ namespace System.Xml
         {
             if (bufferedWrite.Length > 0)
             {
-                await stream.WriteAsync(bufferedWrite.GetBuffer(), 0, bufferedWrite.Length);
+                await stream.WriteAsync(bufferedWrite.GetBuffer(), 0, bufferedWrite.Length).ConfigureAwait(false);
                 bufferedWrite.Reset();
             }
         }
@@ -1381,7 +1381,7 @@ namespace System.Xml
 
             state = MimeWriterState.Content;
             bufferedWrite.Write(MimeGlobals.CRLF);
-            await FlushAsync();
+            await FlushAsync().ConfigureAwait(false);
             contentStream = stream;
             return contentStream;
         }

--- a/src/System.ServiceModel.Primitives/src/System/IdentityModel/Selectors/SecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Primitives/src/System/IdentityModel/Selectors/SecurityTokenProvider.cs
@@ -59,7 +59,7 @@ namespace System.IdentityModel.Selectors
 
         public async Task<SecurityToken> GetTokenAsync(TimeSpan timeout)
         {
-            SecurityToken token = await GetTokenCoreAsync(timeout);
+            SecurityToken token = await GetTokenCoreAsync(timeout).ConfigureAwait(false);
             if (token == null)
             {
                 throw Fx.Exception.AsError(new SecurityTokenException(SRP.Format(SRP.TokenProviderUnableToGetToken, this)));
@@ -144,7 +144,7 @@ namespace System.IdentityModel.Selectors
                 throw Fx.Exception.ArgumentNull(nameof(tokenToBeRenewed));
             }
 
-            SecurityToken token = await RenewTokenCoreAsync(timeout, tokenToBeRenewed);
+            SecurityToken token = await RenewTokenCoreAsync(timeout, tokenToBeRenewed).ConfigureAwait(false);
             if (token == null)
             {
                 throw Fx.Exception.AsError(new SecurityTokenException(SRP.Format(SRP.TokenProviderUnableToRenewToken, this)));
@@ -217,7 +217,7 @@ namespace System.IdentityModel.Selectors
                 throw Fx.Exception.ArgumentNull(nameof(token));
             }
 
-            await CancelTokenCoreAsync(timeout, token);
+            await CancelTokenCoreAsync(timeout, token).ConfigureAwait(false);
         }
 
         protected virtual void CancelTokenCore(TimeSpan timeout, SecurityToken token)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/ChannelFactory.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/ChannelFactory.cs
@@ -149,7 +149,7 @@ namespace System.ServiceModel
                 // Only want to call Close if it is in the Opened state
                 if (State == CommunicationState.Opened)
                 {
-                    await ((IAsyncCommunicationObject)this).CloseAsync(DefaultCloseTimeout);
+                    await ((IAsyncCommunicationObject)this).CloseAsync(DefaultCloseTimeout).ConfigureAwait(false);
                 }
                 // Anything not closed by this point should be aborted
                 if (State != CommunicationState.Closed)
@@ -286,7 +286,7 @@ namespace System.ServiceModel
         {
             if (InnerFactory != null)
             {
-                await CloseOtherAsync(InnerFactory, timeout);
+                await CloseOtherAsync(InnerFactory, timeout).ConfigureAwait(false);
             }
         }
 
@@ -304,7 +304,7 @@ namespace System.ServiceModel
         {
             if (InnerFactory != null)
             {
-                await OpenOtherAsync(InnerFactory, timeout);
+                await OpenOtherAsync(InnerFactory, timeout).ConfigureAwait(false);
             }
         }
 

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/BufferedReadStream.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/BufferedReadStream.cs
@@ -270,7 +270,7 @@ namespace System.ServiceModel.Channels
         {
             Contract.Assert(_readPos == _readLen, "Buffer must be empty");
             _buffer[0] = preBufferedByte;
-            _readLen = 1 + await _stream.ReadAsync(_buffer, 1, _bufferSize - 1, cancellationToken);
+            _readLen = 1 + await _stream.ReadAsync(_buffer, 1, _bufferSize - 1, cancellationToken).ConfigureAwait(false);
             _readPos = 0;
         }
 
@@ -289,12 +289,12 @@ namespace System.ServiceModel.Channels
             Contract.Assert(IsBufferEmpty || _readLen < _bufferSize);
             if (IsBufferEmpty)
             {
-                _readLen = await _stream.ReadAsync(_buffer, 0, _bufferSize, cancellationToken);
+                _readLen = await _stream.ReadAsync(_buffer, 0, _bufferSize, cancellationToken).ConfigureAwait(false);
                 _readPos = 0;
             }
             else
             {
-                _readLen += await _stream.ReadAsync(_buffer, _readLen, _bufferSize - _readLen, cancellationToken);
+                _readLen += await _stream.ReadAsync(_buffer, _readLen, _bufferSize - _readLen, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ChannelFactoryBase.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ChannelFactoryBase.cs
@@ -208,14 +208,14 @@ namespace System.ServiceModel.Channels
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             foreach (IChannel channel in currentChannels)
             {
-                await CloseOtherAsync(channel, timeoutHelper.RemainingTime());
+                await CloseOtherAsync(channel, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             // CommunicationObjectManager (_channels) is not a CommunicationObject,
             // and it's close method waits for it to not be busy. Calling CloseAsync
             // is the correct option here as there's no need to block this thread
             // waiting on a signal from another thread to notify it's no longer busy.
-            await _channels.CloseAsync(timeoutHelper.RemainingTime());
+            await _channels.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
     }
 }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ChannelReliableSession.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ChannelReliableSession.cs
@@ -130,7 +130,7 @@ namespace System.ServiceModel.Channels
 
         public virtual async Task CloseAsync(TimeSpan timeout)
         {
-            await Guard.CloseAsync(timeout);
+            await Guard.CloseAsync(timeout).ConfigureAwait(false);
             _inactivityTimer.Abort();
         }
 
@@ -605,7 +605,7 @@ namespace System.ServiceModel.Channels
             }
 
             var start = DateTime.UtcNow;
-            Message response = await _requestor.RequestAsync(timeout);
+            Message response = await _requestor.RequestAsync(timeout).ConfigureAwait(false);
             ProcessCreateSequenceResponse(response, start);
             _requestor = null;
         }
@@ -622,7 +622,7 @@ namespace System.ServiceModel.Channels
 
         public override async Task CloseAsync(TimeSpan timeout)
         {
-            await base.CloseAsync(timeout);
+            await base.CloseAsync(timeout).ConfigureAwait(false);
             _pollingTimer.Abort();
         }
 
@@ -684,7 +684,7 @@ namespace System.ServiceModel.Channels
                             _pollingMode = PollingMode.KeepAlive;
                     }
 
-                    await _pollingHandler();
+                    await _pollingHandler().ConfigureAwait(false);
                     _pollingTimer.Set(GetPollingInterval());
                 }
                 finally

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ClientReliableChannelBinder.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ClientReliableChannelBinder.cs
@@ -150,7 +150,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                (bool success, TChannel channel) = await Synchronizer.TryGetChannelForOutputAsync(timeoutHelper.RemainingTime(), maskingMode);
+                (bool success, TChannel channel) = await Synchronizer.TryGetChannelForOutputAsync(timeoutHelper.RemainingTime(), maskingMode).ConfigureAwait(false);
 
                 if (!success)
                 {
@@ -171,7 +171,7 @@ namespace System.ServiceModel.Channels
                 try
                 {
                     return await OnRequestAsync(channel, message, timeoutHelper.RemainingTime(),
-                        maskingMode);
+                        maskingMode).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -288,11 +288,11 @@ namespace System.ServiceModel.Channels
                 Message message;
                 if (channel is IAsyncDuplexSessionChannel)
                 {
-                    (success, message) = await ((IAsyncDuplexSessionChannel)channel).TryReceiveAsync(timeout);
+                    (success, message) = await ((IAsyncDuplexSessionChannel)channel).TryReceiveAsync(timeout).ConfigureAwait(false);
                 }
                 else
                 {
-                    (success, message) = await TaskHelpers.FromAsync<TimeSpan, bool, Message>(channel.BeginTryReceive, channel.EndTryReceive, timeout, null);
+                    (success, message) = await TaskHelpers.FromAsync<TimeSpan, bool, Message>(channel.BeginTryReceive, channel.EndTryReceive, timeout, null).ConfigureAwait(false);
                 }
 
                 if (success && message == null)
@@ -462,7 +462,7 @@ namespace System.ServiceModel.Channels
             protected override async Task OnSendAsync(TRequestChannel channel, Message message,
                 TimeSpan timeout)
             {
-                message = await OnRequestAsync(channel, message, timeout, DefaultMaskingMode);
+                message = await OnRequestAsync(channel, message, timeout, DefaultMaskingMode).ConfigureAwait(false);
                 EnqueueMessageIfNotNull(message);
             }
 
@@ -476,7 +476,7 @@ namespace System.ServiceModel.Channels
 
             public override async Task<(bool, RequestContext)> TryReceiveAsync(TimeSpan timeout)
             {
-                (bool success, Message message) = await GetInputMessages().TryDequeueAsync(timeout);
+                (bool success, Message message) = await GetInputMessages().TryDequeueAsync(timeout).ConfigureAwait(false);
                 RequestContext requestContext = WrapMessage(message);
                 return (success, requestContext);
             }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/CommunicationObject.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/CommunicationObject.cs
@@ -106,7 +106,7 @@ namespace System.ServiceModel.Channels
             get { return _state; }
         }
 
-        protected object ThisLock { 
+        protected object ThisLock {
             get
             {
 #if DEBUG
@@ -223,7 +223,7 @@ namespace System.ServiceModel.Channels
         private async Task CloseAsyncInternal(TimeSpan timeout)
         {
             await TaskHelpers.EnsureDefaultTaskScheduler();
-            await ((IAsyncCommunicationObject)this).CloseAsync(timeout);
+            await ((IAsyncCommunicationObject)this).CloseAsync(timeout).ConfigureAwait(false);
         }
 
         async Task IAsyncCommunicationObject.CloseAsync(TimeSpan timeout)
@@ -271,7 +271,7 @@ namespace System.ServiceModel.Channels
                                 throw TraceUtility.ThrowHelperError(CreateBaseClassMethodNotCalledException("OnClosing"), Guid.Empty, this);
                             }
 
-                            await OnCloseAsyncInternal(actualTimeout.RemainingTime());
+                            await OnCloseAsyncInternal(actualTimeout.RemainingTime()).ConfigureAwait(false);
 
                             OnClosed();
                             if (!_onClosedCalled)
@@ -310,7 +310,7 @@ namespace System.ServiceModel.Channels
             if (SupportsAsyncOpenClose)
             {
                 // The class supports OnCloseAsync(), so use it
-                await OnCloseAsync(timeout);
+                await OnCloseAsync(timeout).ConfigureAwait(false);
             }
             else
             {
@@ -318,13 +318,13 @@ namespace System.ServiceModel.Channels
                 // If this is a synchronous close, invoke the synchronous OnClose.
                 if (_isSynchronousClose)
                 {
-                    await TaskHelpers.CallActionAsync(OnClose, timeout);
+                    await TaskHelpers.CallActionAsync(OnClose, timeout).ConfigureAwait(false);
                 }
                 else
                 {
                     // The class does not support OnCloseAsync, and this is an asynchronous
                     // close, so use the Begin/End pattern
-                    await Task.Factory.FromAsync(OnBeginClose, OnEndClose, timeout, TaskCreationOptions.RunContinuationsAsynchronously);
+                    await Task.Factory.FromAsync(OnBeginClose, OnEndClose, timeout, TaskCreationOptions.RunContinuationsAsynchronously).ConfigureAwait(false);
                 }
             }
         }
@@ -531,7 +531,7 @@ namespace System.ServiceModel.Channels
                 // EnsureDefaultTaskScheduler must be called after OnOpening to ensure that any SynchronizationContext
                 // is captured by the DispatchRuntime
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                await OnOpenAsyncInternal(actualTimeout.RemainingTime());
+                await OnOpenAsyncInternal(actualTimeout.RemainingTime()).ConfigureAwait(false);
 
                 OnOpened();
                 if (!_onOpenedCalled)
@@ -560,7 +560,7 @@ namespace System.ServiceModel.Channels
             if (SupportsAsyncOpenClose)
             {
                 // The class supports OnOpenAsync(), so use it
-                await OnOpenAsync(timeout);
+                await OnOpenAsync(timeout).ConfigureAwait(false);
             }
             else
             {
@@ -568,12 +568,12 @@ namespace System.ServiceModel.Channels
                 // If this is a synchronous open, invoke the synchronous OnOpen
                 if (_isSynchronousOpen)
                 {
-                    await TaskHelpers.CallActionAsync(OnOpen, timeout);
+                    await TaskHelpers.CallActionAsync(OnOpen, timeout).ConfigureAwait(false);
                 }
                 else
                 {
                     // The class does not support OnOpenAsync, so use the Begin/End pattern
-                    await Task.Factory.FromAsync(OnBeginOpen, OnEndOpen, timeout, TaskCreationOptions.RunContinuationsAsynchronously);
+                    await Task.Factory.FromAsync(OnBeginOpen, OnEndOpen, timeout, TaskCreationOptions.RunContinuationsAsynchronously).ConfigureAwait(false);
                 }
             }
         }
@@ -1025,7 +1025,7 @@ namespace System.ServiceModel.Channels
                 communicationObject._isSynchronousOpen = _isSynchronousOpen;
                 return ((IAsyncCommunicationObject)communicationObject).OpenAsync(timeout);
             }
-            
+
             // Other object isn't an internal implementation so we need to match calling the
             // sync/async pattern of the Open call that was initially made.
             // If the current object is being opened synchronously, use the synchronous
@@ -1171,13 +1171,13 @@ namespace System.ServiceModel.Channels
         public static async Task OnCloseAsyncInternal(CommunicationObject communicationObject, TimeSpan timeout)
         {
             await TaskHelpers.EnsureDefaultTaskScheduler();
-            await communicationObject.OnCloseAsync(timeout);
+            await communicationObject.OnCloseAsync(timeout).ConfigureAwait(false);
         }
 
         public static async Task OnOpenAsyncInternal(CommunicationObject communicationObject, TimeSpan timeout)
         {
             await TaskHelpers.EnsureDefaultTaskScheduler();
-            await communicationObject.OnOpenAsync(timeout);
+            await communicationObject.OnOpenAsync(timeout).ConfigureAwait(false);
         }
     }
 }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/DelegatingStream.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/DelegatingStream.cs
@@ -46,12 +46,12 @@ namespace System.ServiceModel.Channels
         {
             if (!_disposed)
             {
-                await BaseStream.DisposeAsync();
+                await BaseStream.DisposeAsync().ConfigureAwait(false);
                 GC.SuppressFinalize(this);
                 _disposed = true;
             }
 
-            await base.DisposeAsync();
+            await base.DisposeAsync().ConfigureAwait(false);
         }
 
         public override long Position

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/DetectEofStream.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/DetectEofStream.cs
@@ -25,7 +25,7 @@ namespace System.ServiceModel.Channels
             {
                 return 0;
             }
-            int returnValue = await base.ReadAsync(buffer, offset, count, cancellationToken);
+            int returnValue = await base.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             if (count != 0 && returnValue == 0)
             {
                 ReceivedEof();
@@ -39,7 +39,7 @@ namespace System.ServiceModel.Channels
             {
                 return 0;
             }
-            int returnValue = await base.ReadAsync(buffer, cancellationToken);
+            int returnValue = await base.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             if (!buffer.IsEmpty && returnValue == 0)
             {
                 ReceivedEof();

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/InputChannel.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/InputChannel.cs
@@ -10,7 +10,7 @@ namespace System.ServiceModel.Channels
     {
         internal static async Task<Message> HelpReceiveAsync(IAsyncInputChannel channel, TimeSpan timeout)
         {
-            (bool success, Message message) = await channel.TryReceiveAsync(timeout);
+            (bool success, Message message) = await channel.TryReceiveAsync(timeout).ConfigureAwait(false);
 
             if (success)
             {

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/InputQueueChannel.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/InputQueueChannel.cs
@@ -94,7 +94,7 @@ namespace System.ServiceModel.Channels
         protected async Task<(bool dequeued, TDisposable item)> DequeueAsync(TimeSpan timeout)
         {
             ThrowIfNotOpened();
-            (bool dequeued, TDisposable item) = await _inputQueue.TryDequeueAsync(timeout);
+            (bool dequeued, TDisposable item) = await _inputQueue.TryDequeueAsync(timeout).ConfigureAwait(false);
 
             if (item == null)
             {
@@ -108,7 +108,7 @@ namespace System.ServiceModel.Channels
         protected async Task<bool> WaitForItemAsync(TimeSpan timeout)
         {
             ThrowIfNotOpened();
-            bool dequeued = await _inputQueue.WaitForItemAsync(timeout);
+            bool dequeued = await _inputQueue.WaitForItemAsync(timeout).ConfigureAwait(false);
 
             ThrowIfFaulted();
             ThrowIfAborted();

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/LayeredChannelFactory.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/LayeredChannelFactory.cs
@@ -57,8 +57,8 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnCloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await base.OnCloseAsync(timeoutHelper.RemainingTime());
-            await InnerChannelFactory.CloseHelperAsync(timeoutHelper.RemainingTime());
+            await base.OnCloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await InnerChannelFactory.CloseHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         protected override void OnClose(TimeSpan timeout)
@@ -122,14 +122,14 @@ namespace System.ServiceModel.Channels
             Message message;
             if (InnerChannel is IAsyncInputChannel asyncInputChannel)
             {
-                message = await asyncInputChannel.ReceiveAsync(timeout);
+                message = await asyncInputChannel.ReceiveAsync(timeout).ConfigureAwait(false);
             }
             else
             {
-                message = await Task.Factory.FromAsync(InnerChannel.BeginReceive, InnerChannel.EndReceive, timeout, null);
+                message = await Task.Factory.FromAsync(InnerChannel.BeginReceive, InnerChannel.EndReceive, timeout, null).ConfigureAwait(false);
             }
 
-            await InternalOnReceiveAsync(message);
+            await InternalOnReceiveAsync(message).ConfigureAwait(false);
             return message;
         }
 
@@ -138,14 +138,14 @@ namespace System.ServiceModel.Channels
             Message message;
             if (InnerChannel is IAsyncInputChannel asyncInputChannel)
             {
-                message = await asyncInputChannel.ReceiveAsync();
+                message = await asyncInputChannel.ReceiveAsync().ConfigureAwait(false);
             }
             else
             {
-                message = await Task.Factory.FromAsync(InnerChannel.BeginReceive, InnerChannel.EndReceive, null);
+                message = await Task.Factory.FromAsync(InnerChannel.BeginReceive, InnerChannel.EndReceive, null).ConfigureAwait(false);
             }
 
-            await InternalOnReceiveAsync(message);
+            await InternalOnReceiveAsync(message).ConfigureAwait(false);
             return message;
         }
 
@@ -187,14 +187,14 @@ namespace System.ServiceModel.Channels
             Message message;
             if (InnerChannel is IAsyncInputChannel asyncInputChannel)
             {
-                (retVal, message) = await asyncInputChannel.TryReceiveAsync(timeout);
+                (retVal, message) = await asyncInputChannel.TryReceiveAsync(timeout).ConfigureAwait(false);
             }
             else
             {
-                (retVal, message) = await TaskHelpers.FromAsync<TimeSpan, bool, Message>(InnerChannel.BeginTryReceive, InnerChannel.EndTryReceive, timeout, null);
+                (retVal, message) = await TaskHelpers.FromAsync<TimeSpan, bool, Message>(InnerChannel.BeginTryReceive, InnerChannel.EndTryReceive, timeout, null).ConfigureAwait(false);
             }
 
-            await InternalOnReceiveAsync(message);
+            await InternalOnReceiveAsync(message).ConfigureAwait(false);
             return (retVal, message);
         }
 
@@ -282,8 +282,8 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnCloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await _innerOutputChannel.CloseHelperAsync(timeout);
-            await base.OnCloseAsync(timeoutHelper.RemainingTime());
+            await _innerOutputChannel.CloseHelperAsync(timeout).ConfigureAwait(false);
+            await base.OnCloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         protected override void OnClose(TimeSpan timeout) => throw ExceptionHelper.PlatformNotSupported();
@@ -295,8 +295,8 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnOpenAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await base.OnOpenAsync(timeoutHelper.RemainingTime());
-            await _innerOutputChannel.OpenHelperAsync(timeoutHelper.RemainingTime());
+            await base.OnOpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await _innerOutputChannel.OpenHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         protected override void OnOpen(TimeSpan timeout)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/LifetimeManager.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/LifetimeManager.cs
@@ -71,7 +71,7 @@ namespace System.ServiceModel.Channels
                 _state = LifetimeState.Closing;
             }
 
-            await OnCloseAsync(timeout);
+            await OnCloseAsync(timeout).ConfigureAwait(false);
             _state = LifetimeState.Closed;
         }
 
@@ -116,7 +116,7 @@ namespace System.ServiceModel.Channels
 
             if (busyWaiter != null)
             {
-                result = await busyWaiter.WaitAsync(timeout, aborting);
+                result = await busyWaiter.WaitAsync(timeout, aborting).ConfigureAwait(false);
                 if (Interlocked.Decrement(ref _busyWaiterCount) == 0)
                 {
                     busyWaiter.Dispose();
@@ -244,7 +244,7 @@ namespace System.ServiceModel.Channels
 
         protected virtual async Task OnCloseAsync(TimeSpan timeout)
         {
-            switch (await CloseCoreAsync(timeout, false))
+            switch (await CloseCoreAsync(timeout, false).ConfigureAwait(false))
             {
                 case CommunicationWaitResult.Expired:
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(SRP.Format(SRP.SFxCloseTimedOut1, timeout)));
@@ -336,7 +336,7 @@ namespace System.ServiceModel.Channels
                 _result = CommunicationWaitResult.Aborted;
             }
 
-            bool expired = !await _tcs.Task.AwaitWithTimeout(timeout);
+            bool expired = !await _tcs.Task.AwaitWithTimeout(timeout).ConfigureAwait(false);
 
             lock (ThisLock)
             {

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/MaxMessageSizeStream.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/MaxMessageSizeStream.cs
@@ -24,7 +24,7 @@ namespace System.ServiceModel.Channels
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             count = PrepareRead(count);
-            int bytesRead = await base.ReadAsync(buffer, offset, count, cancellationToken);
+            int bytesRead = await base.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             return FinishRead(bytesRead);
         }
 
@@ -35,7 +35,7 @@ namespace System.ServiceModel.Channels
             {
                 buffer = buffer.Slice(0, readCount);
             }
-            int bytesRead = await base.ReadAsync(buffer, cancellationToken);
+            int bytesRead = await base.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             return FinishRead(bytesRead);
         }
 

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/Message.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/Message.cs
@@ -720,7 +720,7 @@ namespace System.ServiceModel.Channels
         public virtual async Task WriteMessageAsync(XmlDictionaryWriter writer)
         {
             EnsureWriteMessageState(writer);
-            await OnWriteMessageAsync(writer);
+            await OnWriteMessageAsync(writer).ConfigureAwait(false);
         }
 
         public virtual async Task OnWriteMessageAsync(XmlDictionaryWriter writer)
@@ -730,8 +730,8 @@ namespace System.ServiceModel.Channels
             // We should call OnWriteBodyContentsAsync instead of WriteBodyContentsAsync here,
             // otherwise EnsureWriteMessageState would get called twice. Also see OnWriteMessage()
             // for the example.
-            await OnWriteBodyContentsAsync(writer);
-            await WriteMessagePostambleAsync(writer);
+            await OnWriteBodyContentsAsync(writer).ConfigureAwait(false);
+            await WriteMessagePostambleAsync(writer).ConfigureAwait(false);
         }
 
         private void EnsureWriteMessageState(XmlDictionaryWriter writer)
@@ -815,8 +815,8 @@ namespace System.ServiceModel.Channels
         {
             if (Version.Envelope != EnvelopeVersion.None)
             {
-                await writer.WriteEndElementAsync();
-                await writer.WriteEndElementAsync();
+                await writer.WriteEndElementAsync().ConfigureAwait(false);
+                await writer.WriteEndElementAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/MessageEncoder.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/MessageEncoder.cs
@@ -66,7 +66,7 @@ namespace System.ServiceModel.Channels
 
             while (offset < currentBufferSize)
             {
-                int count = await stream.ReadAsync(buffer, offset, currentBufferSize - offset, cancellationToken);
+                int count = await stream.ReadAsync(buffer, offset, currentBufferSize - offset, cancellationToken).ConfigureAwait(false);
                 if (count == 0)
                 {
                     stream.Dispose();
@@ -95,7 +95,7 @@ namespace System.ServiceModel.Channels
         // used for buffered streaming
         internal virtual async Task<Message> ReadMessageAsync(Stream stream, BufferManager bufferManager, int maxBufferSize, string contentType, CancellationToken cancellationToken)
         {
-            return ReadMessage(await BufferMessageStreamAsync(stream, bufferManager, maxBufferSize, cancellationToken), bufferManager, contentType);
+            return ReadMessage(await BufferMessageStreamAsync(stream, bufferManager, maxBufferSize, cancellationToken).ConfigureAwait(false), bufferManager, contentType);
         }
 
         public override string ToString()

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/MtomMessageEncoder.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/MtomMessageEncoder.cs
@@ -563,16 +563,16 @@ namespace System.ServiceModel.Channels
             XmlDictionaryWriter xmlWriter = _factory.TakeStreamedWriter(stream, startInfo, boundary, startUri, writeMessageHeaders);
             if (_writeEncoding.WebName == "utf-8")
             {
-                await message.WriteMessageAsync(xmlWriter);
+                await message.WriteMessageAsync(xmlWriter).ConfigureAwait(false);
             }
             else
             {
-                await xmlWriter.WriteStartDocumentAsync();
-                await message.WriteMessageAsync(xmlWriter);
-                await xmlWriter.WriteEndDocumentAsync();
+                await xmlWriter.WriteStartDocumentAsync().ConfigureAwait(false);
+                await message.WriteMessageAsync(xmlWriter).ConfigureAwait(false);
+                await xmlWriter.WriteEndDocumentAsync().ConfigureAwait(false);
             }
 
-            await xmlWriter.FlushAsync();
+            await xmlWriter.FlushAsync().ConfigureAwait(false);
             _factory.ReturnStreamedWriter(xmlWriter);
 
             if (WcfEventSource.Instance.StreamedMessageWrittenByEncoderIsEnabled())

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ProducerConsumerStream.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ProducerConsumerStream.cs
@@ -87,7 +87,7 @@ namespace System.ServiceModel.Channels
                 Contract.Assert(!_buffer.Task.IsCompleted, "Buffer task should not already be completed");
                 Contract.Assert(_currentBuffer == WriteBufferWrapper.EmptyContainer, "The current buffer should be the EmptyContainer");
                 _buffer.TrySetResult(new WriteBufferWrapper(buffer, offset, count));
-                return await _dataAvail.Task;
+                return await _dataAvail.Task.ConfigureAwait(false);
             }
         }
         public override void Write(byte[] buffer, int offset, int count)
@@ -132,7 +132,7 @@ namespace System.ServiceModel.Channels
                 {
                     if (_currentBuffer == WriteBufferWrapper.EmptyContainer)
                     {
-                        _currentBuffer = await _buffer.Task;
+                        _currentBuffer = await _buffer.Task.ConfigureAwait(false);
                         _buffer = new TaskCompletionSource<WriteBufferWrapper>();
                     }
 

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
@@ -252,11 +252,11 @@ namespace System.ServiceModel.Channels
             try
             {
                 OnShutdown();
-                await OnCloseAsync(timeoutHelper.RemainingTime());
+                await OnCloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
                 if (channel != null)
                 {
-                    await CloseChannelAsync(channel, timeoutHelper.RemainingTime());
+                    await CloseChannelAsync(channel, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
 
                 TransitionToClosed();
@@ -562,7 +562,7 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                await OnOpenAsync(timeout);
+                await OnOpenAsync(timeout).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -584,7 +584,7 @@ namespace System.ServiceModel.Channels
                 }
             }
 
-            await Synchronizer.StartSynchronizingAsync();
+            await Synchronizer.StartSynchronizingAsync().ConfigureAwait(false);
             OnOpened();
         }
 
@@ -615,7 +615,7 @@ namespace System.ServiceModel.Channels
             try
             {
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                (bool success, TChannel channel) = await Synchronizer.TryGetChannelForOutputAsync(timeoutHelper.RemainingTime(), maskingMode);
+                (bool success, TChannel channel) = await Synchronizer.TryGetChannelForOutputAsync(timeoutHelper.RemainingTime(), maskingMode).ConfigureAwait(false);
                 if (!success)
                 {
                     if (!ReliableChannelBinderHelper.MaskHandled(maskingMode))
@@ -636,7 +636,7 @@ namespace System.ServiceModel.Channels
 
                 try
                 {
-                    await OnSendAsync(channel, message, timeoutHelper.RemainingTime());
+                    await OnSendAsync(channel, message, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -748,7 +748,7 @@ namespace System.ServiceModel.Channels
                 try
                 {
                     (bool success, TChannel channel) = await Synchronizer.TryGetChannelForInputAsync(
-                        CanGetChannelForReceive, timeoutHelper.RemainingTime());
+                        CanGetChannelForReceive, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     success = !success;
 
                     // the synchronizer is faulted and not reestablishing or closed, or the call timed
@@ -761,7 +761,7 @@ namespace System.ServiceModel.Channels
                     try
                     {
                         RequestContext requestContext;
-                        (success, requestContext) = await OnTryReceiveAsync(channel, timeoutHelper.RemainingTime());
+                        (success, requestContext) = await OnTryReceiveAsync(channel, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
                         // timed out || got message, return immediately
                         if (!success || (requestContext != null))
@@ -999,7 +999,7 @@ namespace System.ServiceModel.Channels
             {
                 bool fault = false;
 
-                await using (await ThisLock.TakeLockAsync())
+                await using (await ThisLock.TakeLockAsync().ConfigureAwait(false))
                 {
                     if (ValidateOpened())
                     {
@@ -1026,7 +1026,7 @@ namespace System.ServiceModel.Channels
                                 return true;
                             }
 
-                            if (await _binder.TryGetChannelAsync(TimeSpan.Zero))
+                            if (await _binder.TryGetChannelAsync(TimeSpan.Zero).ConfigureAwait(false))
                             {
                                 if (CurrentChannel == null)
                                 {
@@ -1448,7 +1448,7 @@ namespace System.ServiceModel.Channels
 
             public async Task StartSynchronizingAsync()
             {
-                await using (await ThisLock.TakeLockAsync())
+                await using (await ThisLock.TakeLockAsync().ConfigureAwait(false))
                 {
                     if (_state == State.Created)
                     {
@@ -1466,7 +1466,7 @@ namespace System.ServiceModel.Channels
 
                     if (CurrentChannel == null)
                     {
-                        if (!await _binder.TryGetChannelAsync(TimeSpan.Zero))
+                        if (!await _binder.TryGetChannelAsync(TimeSpan.Zero).ConfigureAwait(false))
                         {
                             return;
                         }
@@ -1549,7 +1549,7 @@ namespace System.ServiceModel.Channels
                 bool faulted = false;
                 bool getChannel = false;
 
-                await using (await ThisLock.TakeLockAsync())
+                await using (await ThisLock.TakeLockAsync().ConfigureAwait(false))
                 {
                     if (!ThrowIfNecessary(maskingMode))
                     {
@@ -1612,7 +1612,7 @@ namespace System.ServiceModel.Channels
                     waiter.GetChannel(true);
                 }
 
-                return await waiter.TryWaitAsync();
+                return await waiter.TryWaitAsync().ConfigureAwait(false);
             }
 
             public void UnblockWaiters()
@@ -1664,7 +1664,7 @@ namespace System.ServiceModel.Channels
 
             public async Task WaitForPendingOperationsAsync(TimeSpan timeout)
             {
-                await using (await ThisLock.TakeLockAsync())
+                await using (await ThisLock.TakeLockAsync().ConfigureAwait(false))
                 {
                     if (_drainEvent != null)
                     {
@@ -1679,7 +1679,7 @@ namespace System.ServiceModel.Channels
 
                 if (_drainEvent != null)
                 {
-                    await _drainEvent.WaitAsync(timeout);
+                    await _drainEvent.WaitAsync(timeout).ConfigureAwait(false);
                 }
             }
 
@@ -1783,7 +1783,7 @@ namespace System.ServiceModel.Channels
                         channel = _channel;
                     }
                     else if (await _synchronizer._binder.TryGetChannelAsync(
-                        _timeoutHelper.RemainingTime()))
+                        _timeoutHelper.RemainingTime()).ConfigureAwait(false))
                     {
                         if (!_synchronizer.CompleteSetChannel(this, out channel))
                         {
@@ -1807,7 +1807,7 @@ namespace System.ServiceModel.Channels
 
                         try
                         {
-                            await channel.OpenHelperAsync(_timeoutHelper.RemainingTime());
+                            await channel.OpenHelperAsync(_timeoutHelper.RemainingTime()).ConfigureAwait(false);
                             throwing = false;
                         }
                         finally
@@ -1830,11 +1830,11 @@ namespace System.ServiceModel.Channels
 
                 public async Task<(bool success, TChannel channel)> TryWaitAsync()
                 {
-                    if (!await WaitAsync())
+                    if (!await WaitAsync().ConfigureAwait(false))
                     {
                         return (false, null);
                     }
-                    else if (_getChannel && !await TryGetChannelAsync())
+                    else if (_getChannel && !await TryGetChannelAsync().ConfigureAwait(false))
                     {
                         return (false, null);
                     }
@@ -1846,7 +1846,7 @@ namespace System.ServiceModel.Channels
                             throw Fx.AssertAndThrow("User of IWaiter called both Set and Fault or Close.");
                         }
 
-                        await _tcs.Task;
+                        await _tcs.Task.ConfigureAwait(false);
                     }
 
                     return (true, _channel);
@@ -1854,7 +1854,7 @@ namespace System.ServiceModel.Channels
 
                 private async Task<bool> WaitAsync()
                 {
-                    if (!await _tcs.Task.AwaitWithTimeout(_timeoutHelper.RemainingTime()))
+                    if (!await _tcs.Task.AwaitWithTimeout(_timeoutHelper.RemainingTime()).ConfigureAwait(false))
                     {
                         if (_synchronizer.RemoveWaiter(this))
                         {
@@ -1862,7 +1862,7 @@ namespace System.ServiceModel.Channels
                         }
                         else
                         {
-                            await _tcs.Task;
+                            await _tcs.Task.ConfigureAwait(false);
                         }
                     }
 
@@ -1973,7 +1973,7 @@ namespace System.ServiceModel.Channels
                         Binder.AddOutputHeaders(message);
                     }
 
-                    await Task.Factory.FromAsync(_innerContext.BeginReply, _innerContext.EndReply, message, timeout, null);
+                    await Task.Factory.FromAsync(_innerContext.BeginReply, _innerContext.EndReply, message, timeout, null).ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException) { }
                 catch (Exception e)
@@ -2006,8 +2006,8 @@ namespace System.ServiceModel.Channels
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
 
-            await ((ISessionChannel<IAsyncDuplexSession>)channel).Session.CloseOutputSessionAsync(timeoutHelper.RemainingTime());
-            await binder.WaitForPendingOperationsAsync(timeoutHelper.RemainingTime());
+            await ((ISessionChannel<IAsyncDuplexSession>)channel).Session.CloseOutputSessionAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await binder.WaitForPendingOperationsAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
             bool lastIteration = (iterationTimeout == TimeSpan.Zero);
@@ -2022,17 +2022,17 @@ namespace System.ServiceModel.Channels
                     bool success;
                     if (channel is IAsyncDuplexSessionChannel)
                     {
-                        (success, message) = await ((IAsyncDuplexSessionChannel)channel).TryReceiveAsync(timeout);
+                        (success, message) = await ((IAsyncDuplexSessionChannel)channel).TryReceiveAsync(timeout).ConfigureAwait(false);
                     }
                     else
                     {
-                        (success, message) = await TaskHelpers.FromAsync<TimeSpan, bool, Message>(channel.BeginTryReceive, channel.EndTryReceive, timeout, null);
+                        (success, message) = await TaskHelpers.FromAsync<TimeSpan, bool, Message>(channel.BeginTryReceive, channel.EndTryReceive, timeout, null).ConfigureAwait(false);
                     }
 
                     receiveThrowing = false;
                     if (success && message == null)
                     {
-                        await channel.CloseHelperAsync(timeoutHelper.RemainingTime());
+                        await channel.CloseHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                         return;
                     }
                 }
@@ -2088,7 +2088,7 @@ namespace System.ServiceModel.Channels
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
 
-            await binder.WaitForPendingOperationsAsync(timeoutHelper.RemainingTime());
+            await binder.WaitForPendingOperationsAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
             bool lastIteration = (iterationTimeout == TimeSpan.Zero);
@@ -2101,12 +2101,12 @@ namespace System.ServiceModel.Channels
                 try
                 {
                     bool success;
-                    (success, context) = await TaskHelpers.FromAsync<TimeSpan, bool, RequestContext>(channel.BeginTryReceiveRequest, channel.EndTryReceiveRequest, iterationTimeout, null);
+                    (success, context) = await TaskHelpers.FromAsync<TimeSpan, bool, RequestContext>(channel.BeginTryReceiveRequest, channel.EndTryReceiveRequest, iterationTimeout, null).ConfigureAwait(false);
 
                     receiveThrowing = false;
                     if (success && context == null)
                     {
-                        await channel.CloseHelperAsync(timeoutHelper.RemainingTime());
+                        await channel.CloseHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                         return;
                     }
                 }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableChannelFactory.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableChannelFactory.cs
@@ -88,9 +88,9 @@ namespace System.ServiceModel.Channels
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             // Closing base first to close channels.  Must close higher channels before closing lower channels.
-            await base.OnCloseAsync(timeoutHelper.RemainingTime());
-            await FaultHelper.CloseAsync(timeoutHelper.RemainingTime());
-            await InnerChannelFactory.CloseHelperAsync(timeoutHelper.RemainingTime());
+            await base.OnCloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await FaultHelper.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await InnerChannelFactory.CloseHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         protected override void OnClose(TimeSpan timeout)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableInputConnection.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableInputConnection.cs
@@ -220,8 +220,8 @@ namespace System.ServiceModel.Channels
         public async Task CloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await _shutdownWaitObject.WaitAsync(timeoutHelper.RemainingTime());
-            await _terminateWaitObject.WaitAsync(timeoutHelper.RemainingTime());
+            await _shutdownWaitObject.WaitAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await _terminateWaitObject.WaitAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
     }
 }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableMessagingHelpers.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableMessagingHelpers.cs
@@ -52,7 +52,7 @@ namespace System.ServiceModel.Channels
             {
                 try
                 {
-                    if (!await _tcs.Task.AwaitWithTimeout(timeout))
+                    if (!await _tcs.Task.AwaitWithTimeout(timeout).ConfigureAwait(false))
                         throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(SRP.Format(SRP.TimeoutOnOperation, timeout)));
                 }
                 finally
@@ -396,7 +396,7 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                if (!await _tcs.Task.AwaitWithTimeout(timeout))
+                if (!await _tcs.Task.AwaitWithTimeout(timeout).ConfigureAwait(false))
                 {
                     if (throwTimeoutException)
                     {
@@ -532,7 +532,7 @@ namespace System.ServiceModel.Channels
             {
                 try
                 {
-                    await binder.CloseAsync(_defaultCloseTimeout);
+                    await binder.CloseAsync(_defaultCloseTimeout).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -575,7 +575,7 @@ namespace System.ServiceModel.Channels
             if (BeforeClose())
                 return;
 
-            await _closeHandle.WaitAsync(timeout);
+            await _closeHandle.WaitAsync(timeout).ConfigureAwait(false);
             AfterClose();
         }
 
@@ -610,8 +610,8 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                await SendFaultAsync(binder, state, _defaultSendTimeout);
-                await AsyncCloseBinder(binder);
+                await SendFaultAsync(binder, state, _defaultSendTimeout).ConfigureAwait(false);
+                await AsyncCloseBinder(binder).ConfigureAwait(false);
                 throwing = false;
             }
             finally
@@ -647,7 +647,7 @@ namespace System.ServiceModel.Channels
                 }
 
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                await SendFaultAsync(binder, state);
+                await SendFaultAsync(binder, state).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -694,7 +694,7 @@ namespace System.ServiceModel.Channels
         protected override async Task SendFaultAsync(IReliableChannelBinder binder, FaultState faultState, TimeSpan timeout)
         {
             var context = faultState.RequestContext;
-            await Task.Factory.FromAsync(context.BeginReply, context.EndReply, faultState.FaultMessage, timeout, null);
+            await Task.Factory.FromAsync(context.BeginReply, context.EndReply, faultState.FaultMessage, timeout, null).ConfigureAwait(false);
             faultState.FaultMessage.Close();
         }
 
@@ -723,7 +723,7 @@ namespace System.ServiceModel.Channels
 
         protected override async Task SendFaultAsync(IReliableChannelBinder binder, Message message, TimeSpan timeout)
         {
-            await binder.SendAsync(message, timeout);
+            await binder.SendAsync(message, timeout).ConfigureAwait(false);
             message.Close();
         }
 
@@ -928,10 +928,10 @@ namespace System.ServiceModel.Channels
 
                 try
                 {
-                    if (await EnsureChannelAsync())
+                    if (await EnsureChannelAsync().ConfigureAwait(false))
                     {
                         request = CreateRequestMessage();
-                        reply = await OnRequestAsync(request, requestTimeout, lastIteration);
+                        reply = await OnRequestAsync(request, requestTimeout, lastIteration).ConfigureAwait(false);
                         requestCompleted = true;
                     }
                 }
@@ -963,7 +963,7 @@ namespace System.ServiceModel.Channels
                 if (lastIteration)
                     break;
 
-                await abortHandle.WaitAsync(iterationTimeoutHelper.RemainingTime());
+                await abortHandle.WaitAsync(iterationTimeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             ThrowTimeoutException();
@@ -1041,7 +1041,7 @@ namespace System.ServiceModel.Channels
 
         protected override async Task<Message> OnRequestAsync(Message request, TimeSpan timeout, bool last)
         {
-            return GetReply(await ClientBinder.RequestAsync(request, timeout, MaskingMode.None), last);
+            return GetReply(await ClientBinder.RequestAsync(request, timeout, MaskingMode.None).ConfigureAwait(false), last);
         }
 
         public override void SetInfo(WsrmMessageInfo info)
@@ -1086,11 +1086,11 @@ namespace System.ServiceModel.Channels
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
 
-            await Binder.SendAsync(request, timeoutHelper.RemainingTime(), MaskingMode.None);
+            await Binder.SendAsync(request, timeoutHelper.RemainingTime(), MaskingMode.None).ConfigureAwait(false);
             TimeSpan receiveTimeout = GetReceiveTimeout(timeoutHelper.RemainingTime());
 
             RequestContext requestContext;
-            (_, requestContext) = await Binder.TryReceiveAsync(receiveTimeout, MaskingMode.None);
+            (_, requestContext) = await Binder.TryReceiveAsync(receiveTimeout, MaskingMode.None).ConfigureAwait(false);
             return requestContext?.RequestMessage;
         }
 
@@ -1157,9 +1157,9 @@ namespace System.ServiceModel.Channels
         protected override async Task<Message> OnRequestAsync(Message request, TimeSpan timeout, bool last)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await Binder.SendAsync(request, timeoutHelper.RemainingTime(), MaskingMode.None);
+            await Binder.SendAsync(request, timeoutHelper.RemainingTime(), MaskingMode.None).ConfigureAwait(false);
             TimeSpan waitTimeout = GetWaitTimeout(timeoutHelper.RemainingTime());
-            await replyHandle.WaitAsync(waitTimeout);
+            await replyHandle.WaitAsync(waitTimeout).ConfigureAwait(false);
             return GetReply(last);
         }
 

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableOutputConnection.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableOutputConnection.cs
@@ -115,11 +115,11 @@ namespace System.ServiceModel.Channels
 
             if (completeTransfer)
             {
-                await CompleteTransferAsync(timeoutHelper.RemainingTime());
+                await CompleteTransferAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
-            await _shutdownHandle.WaitAsync(timeoutHelper.RemainingTime());
-            await _sendGuard.CloseAsync(timeoutHelper.RemainingTime());
+            await _shutdownHandle.WaitAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await _sendGuard.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             Strategy.Close();
         }
 
@@ -144,12 +144,12 @@ namespace System.ServiceModel.Channels
                         throw Fx.AssertAndThrow("The isLast overload does not take a state.");
                     }
 
-                    attemptInfo = await Strategy.AddLastAsync(message, helper.RemainingTime(), null);
+                    attemptInfo = await Strategy.AddLastAsync(message, helper.RemainingTime(), null).ConfigureAwait(false);
                 }
                 else
                 {
                     bool success;
-                    (attemptInfo, success) = await Strategy.AddAsync(message, helper.RemainingTime(), state);
+                    (attemptInfo, success) = await Strategy.AddAsync(message, helper.RemainingTime(), state).ConfigureAwait(false);
                     if (!success)
                     {
                         return false;
@@ -176,7 +176,7 @@ namespace System.ServiceModel.Channels
             {
                 try
                 {
-                    await _sendAsyncHandler(attemptInfo, helper.RemainingTime(), false);
+                    await _sendAsyncHandler(attemptInfo, helper.RemainingTime(), false).ConfigureAwait(false);
                 }
                 catch (QuotaExceededException)
                 {
@@ -203,7 +203,7 @@ namespace System.ServiceModel.Channels
             {
                 try
                 {
-                    await _sendAsyncHandler(attemptInfo, _sendTimeout, true);
+                    await _sendAsyncHandler(attemptInfo, _sendTimeout, true).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -308,7 +308,7 @@ namespace System.ServiceModel.Channels
                                 break;
                             }
 
-                            await _sendAsyncHandler(attemptInfo, _sendTimeout, true);
+                            await _sendAsyncHandler(attemptInfo, _sendTimeout, true).ConfigureAwait(false);
                         }
                         finally
                         {

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableOutputSessionChannel.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableOutputSessionChannel.cs
@@ -97,7 +97,7 @@ namespace System.ServiceModel.Channels
         private async Task CloseSequenceAsync(TimeSpan timeout)
         {
             CreateCloseRequestor();
-            Message closeReply = await _closeRequestor.RequestAsync(timeout);
+            Message closeReply = await _closeRequestor.RequestAsync(timeout).ConfigureAwait(false);
             ProcessCloseOrTerminateReply(true, closeReply);
         }
 
@@ -244,16 +244,16 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnCloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await Connection.CloseAsync(timeoutHelper.RemainingTime());
+            await Connection.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             if (Settings.ReliableMessagingVersion == ReliableMessagingVersion.WSReliableMessaging11)
             {
-                await CloseSequenceAsync(timeoutHelper.RemainingTime());
+                await CloseSequenceAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
-            await TerminateSequenceAsync(timeoutHelper.RemainingTime());
-            await _session.CloseAsync(timeoutHelper.RemainingTime());
-            await _binder.CloseAsync(timeoutHelper.RemainingTime(), MaskingMode.Handled);
+            await TerminateSequenceAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await _session.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await _binder.CloseAsync(timeoutHelper.RemainingTime(), MaskingMode.Handled).ConfigureAwait(false);
         }
 
         protected override void OnClosed()
@@ -270,7 +270,7 @@ namespace System.ServiceModel.Channels
             using (Message message = WsrmUtilities.CreateAckRequestedMessage(Settings.MessageVersion,
                 Settings.ReliableMessagingVersion, ReliableSession.OutputID))
             {
-                await OnConnectionSendAsync(message, timeout, false, true);
+                await OnConnectionSendAsync(message, timeout, false, true).ConfigureAwait(false);
             }
         }
 
@@ -291,7 +291,7 @@ namespace System.ServiceModel.Channels
                 {
                     _session.OnLocalActivity();
                     await OnConnectionSendAsync(attemptInfo.Message, timeout,
-                        (attemptInfo.RetryCount == Settings.MaxRetryCount), maskUnhandledException);
+                        (attemptInfo.RetryCount == Settings.MaxRetryCount), maskUnhandledException).ConfigureAwait(false);
                 }
             }
         }
@@ -337,22 +337,22 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                await _binder.OpenAsync(timeoutHelper.RemainingTime());
-                await _session.OpenAsync(timeoutHelper.RemainingTime());
+                await _binder.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                await _session.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 throwing = false;
             }
             finally
             {
                 if (throwing)
                 {
-                    await Binder.CloseAsync(timeoutHelper.RemainingTime());
+                    await Binder.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
             }
         }
 
         protected override async Task OnSendAsync(Message message, TimeSpan timeout)
         {
-            if (!await Connection.AddMessageAsync(message, timeout, null))
+            if (!await Connection.AddMessageAsync(message, timeout, null).ConfigureAwait(false))
                 ThrowInvalidAddException();
         }
 
@@ -378,7 +378,7 @@ namespace System.ServiceModel.Channels
             using (Message request = WsrmUtilities.CreateAckRequestedMessage(Settings.MessageVersion,
                 Settings.ReliableMessagingVersion, ReliableSession.OutputID))
             {
-                await OnConnectionSendMessageAsync(request, DefaultSendTimeout, MaskingMode.All);
+                await OnConnectionSendMessageAsync(request, DefaultSendTimeout, MaskingMode.All).ConfigureAwait(false);
             }
         }
 
@@ -507,7 +507,7 @@ namespace System.ServiceModel.Channels
 
                             try
                             {
-                                await OnConnectionSendAsync(response, DefaultSendTimeout, false, true);
+                                await OnConnectionSendAsync(response, DefaultSendTimeout, false, true).ConfigureAwait(false);
                             }
                             finally
                             {
@@ -580,12 +580,12 @@ namespace System.ServiceModel.Channels
                 _session.CloseSession();
                 Message message = WsrmUtilities.CreateTerminateMessage(Settings.MessageVersion,
                     reliableMessagingVersion, _session.OutputID);
-                await OnConnectionSendMessageAsync(message, timeout, MaskingMode.Handled);
+                await OnConnectionSendMessageAsync(message, timeout, MaskingMode.Handled).ConfigureAwait(false);
             }
             else if (reliableMessagingVersion == ReliableMessagingVersion.WSReliableMessaging11)
             {
                 CreateTerminateRequestor();
-                Message terminateReply = await _terminateRequestor.RequestAsync(timeout);
+                Message terminateReply = await _terminateRequestor.RequestAsync(timeout).ConfigureAwait(false);
 
                 if (terminateReply != null)
                 {
@@ -662,7 +662,7 @@ namespace System.ServiceModel.Channels
             {
                 try
                 {
-                    reply = await binder.RequestAsync(message, timeout, maskingMode);
+                    reply = await binder.RequestAsync(message, timeout, maskingMode).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -682,22 +682,22 @@ namespace System.ServiceModel.Channels
             else
             {
                 maskingMode |= MaskingMode.Handled;
-                reply = await binder.RequestAsync(message, timeout, maskingMode);
+                reply = await binder.RequestAsync(message, timeout, maskingMode).ConfigureAwait(false);
 
                 if (reply != null)
                 {
-                    await ProcessMessageAsync(reply);
+                    await ProcessMessageAsync(reply).ConfigureAwait(false);
                 }
             }
         }
 
         protected override async Task OnConnectionSendMessageAsync(Message message, TimeSpan timeout, MaskingMode maskingMode)
         {
-            Message reply = await binder.RequestAsync(message, timeout, maskingMode);
+            Message reply = await binder.RequestAsync(message, timeout, maskingMode).ConfigureAwait(false);
 
             if (reply != null)
             {
-                await ProcessMessageAsync(reply);
+                await ProcessMessageAsync(reply).ConfigureAwait(false);
             }
         }
 
@@ -739,7 +739,7 @@ namespace System.ServiceModel.Channels
             {
                 try
                 {
-                    await Binder.SendAsync(message, timeout, maskingMode);
+                    await Binder.SendAsync(message, timeout, maskingMode).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -759,7 +759,7 @@ namespace System.ServiceModel.Channels
             else
             {
                 maskingMode |= MaskingMode.Handled;
-                await Binder.SendAsync(message, timeout, maskingMode);
+                await Binder.SendAsync(message, timeout, maskingMode).ConfigureAwait(false);
             }
         }
 
@@ -813,7 +813,7 @@ namespace System.ServiceModel.Channels
             {
                 while (true)
                 {
-                    (bool success, RequestContext context) = await Binder.TryReceiveAsync(TimeSpan.MaxValue);
+                    (bool success, RequestContext context) = await Binder.TryReceiveAsync(TimeSpan.MaxValue).ConfigureAwait(false);
                     if (success)
                     {
                         if (context != null)
@@ -821,7 +821,7 @@ namespace System.ServiceModel.Channels
                             using (context)
                             {
                                 Message requestMessage = context.RequestMessage;
-                                await ProcessMessageAsync(requestMessage);
+                                await ProcessMessageAsync(requestMessage).ConfigureAwait(false);
                                 context.Close(DefaultCloseTimeout);
                             }
                         }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableRequestSessionChannel.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ReliableRequestSessionChannel.cs
@@ -77,7 +77,7 @@ namespace System.ServiceModel.Channels
         private async Task CloseSequenceAsync(TimeSpan timeout)
         {
             CreateCloseRequestor();
-            Message closeReply = await closeRequestor.RequestAsync(timeout);
+            Message closeReply = await closeRequestor.RequestAsync(timeout).ConfigureAwait(false);
             ProcessCloseOrTerminateReply(true, closeReply);
         }
 
@@ -248,17 +248,17 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnCloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await connection.CloseAsync(timeoutHelper.RemainingTime());
-            await WaitForShutdownAsync(timeoutHelper.RemainingTime());
+            await connection.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await WaitForShutdownAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
             if (settings.ReliableMessagingVersion == ReliableMessagingVersion.WSReliableMessaging11)
             {
-                await CloseSequenceAsync(timeoutHelper.RemainingTime());
+                await CloseSequenceAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
-            await TerminateSequenceAsync(timeoutHelper.RemainingTime());
-            await session.CloseAsync(timeoutHelper.RemainingTime());
-            await binder.CloseAsync(timeoutHelper.RemainingTime(), MaskingMode.Handled);
+            await TerminateSequenceAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await session.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await binder.CloseAsync(timeoutHelper.RemainingTime(), MaskingMode.Handled).ConfigureAwait(false);
         }
 
         protected override void OnClose(TimeSpan timeout)
@@ -296,13 +296,13 @@ namespace System.ServiceModel.Channels
                 if (attemptInfo.RetryCount < settings.MaxRetryCount)
                 {
                     maskingMode |= MaskingMode.Handled;
-                    reply = await binder.RequestAsync(attemptInfo.Message, timeout, maskingMode);
+                    reply = await binder.RequestAsync(attemptInfo.Message, timeout, maskingMode).ConfigureAwait(false);
                 }
                 else
                 {
                     try
                     {
-                        reply = await binder.RequestAsync(attemptInfo.Message, timeout, maskingMode);
+                        reply = await binder.RequestAsync(attemptInfo.Message, timeout, maskingMode).ConfigureAwait(false);
                     }
                     catch (Exception e)
                     {
@@ -365,15 +365,15 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                await binder.OpenAsync(timeoutHelper.RemainingTime());
-                await session.OpenAsync(timeoutHelper.RemainingTime());
+                await binder.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                await session.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 throwing = false;
             }
             finally
             {
                 if (throwing)
                 {
-                    await binder.CloseAsync(timeoutHelper.RemainingTime());
+                    await binder.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
             }
         }
@@ -398,7 +398,7 @@ namespace System.ServiceModel.Channels
         private async Task PollingCallback()
         {
             var message = CreateAckRequestedMessage();
-            var reply = await binder.RequestAsync(message, DefaultSendTimeout, MaskingMode.All);
+            var reply = await binder.RequestAsync(message, DefaultSendTimeout, MaskingMode.All).ConfigureAwait(false);
             if (reply != null)
             {
                 ProcessReply(reply, null, 0);
@@ -631,7 +631,7 @@ namespace System.ServiceModel.Channels
         private async Task TerminateSequenceAsync(TimeSpan timeout)
         {
             CreateTerminateRequestor();
-            Message terminateReply = await terminateRequestor.RequestAsync(timeout);
+            Message terminateReply = await terminateRequestor.RequestAsync(timeout).ConfigureAwait(false);
 
             if (terminateReply != null)
             {
@@ -742,7 +742,7 @@ namespace System.ServiceModel.Channels
             public async Task SendRequestAsync(Message message, TimeoutHelper timeoutHelper)
             {
                 _originalTimeout = timeoutHelper.OriginalTimeout;
-                if (!await _parent.connection.AddMessageAsync(message, timeoutHelper.RemainingTime(), this))
+                if (!await _parent.connection.AddMessageAsync(message, timeoutHelper.RemainingTime(), this).ConfigureAwait(false))
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(_parent.GetInvalidAddException());
             }
 
@@ -788,7 +788,7 @@ namespace System.ServiceModel.Channels
 
                         if (wait)
                         {
-                            expired = !await TaskHelpers.AwaitWithTimeout(_tcs.Task, timeoutHelper.RemainingTime());
+                            expired = !await TaskHelpers.AwaitWithTimeout(_tcs.Task, timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
                             lock (ThisLock)
                             {

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/RequestChannel.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/RequestChannel.cs
@@ -85,7 +85,7 @@ namespace System.ServiceModel.Channels
             IRequestBase[] pendingRequests = SetupWaitForPendingRequests();
             if (pendingRequests != null)
             {
-                if (!await _closedTcs.Task.AwaitWithTimeout(timeout))
+                if (!await _closedTcs.Task.AwaitWithTimeout(timeout).ConfigureAwait(false))
                 {
                     foreach (IRequestBase request in pendingRequests)
                     {
@@ -235,7 +235,7 @@ namespace System.ServiceModel.Channels
         private async Task<Message> RequestAsyncInternal(Message message, TimeSpan timeout)
         {
             await TaskHelpers.EnsureDefaultTaskScheduler();
-            return await RequestAsync(message, timeout);
+            return await RequestAsync(message, timeout).ConfigureAwait(false);
         }
 
         public async Task<Message> RequestAsync(Message message, TimeSpan timeout)
@@ -264,7 +264,7 @@ namespace System.ServiceModel.Channels
                 TimeSpan savedTimeout = timeoutHelper.RemainingTime();
                 try
                 {
-                    await request.SendRequestAsync(message, timeoutHelper);
+                    await request.SendRequestAsync(message, timeoutHelper).ConfigureAwait(false);
                 }
                 catch (TimeoutException timeoutException)
                 {
@@ -276,7 +276,7 @@ namespace System.ServiceModel.Channels
 
                 try
                 {
-                    reply = await request.ReceiveReplyAsync(timeoutHelper);
+                    reply = await request.ReceiveReplyAsync(timeoutHelper).ConfigureAwait(false);
                 }
                 catch (TimeoutException timeoutException)
                 {

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
@@ -124,11 +124,11 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnCloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await base.OnCloseAsync(timeout);
-            await CloseProtocolFactoryAsync(false, timeoutHelper.RemainingTime());
+            await base.OnCloseAsync(timeout).ConfigureAwait(false);
+            await CloseProtocolFactoryAsync(false, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             if (_sessionClientSettings != null)
             {
-                await _sessionClientSettings.CloseAsync(timeoutHelper.RemainingTime());
+                await _sessionClientSettings.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
         }
 
@@ -173,8 +173,8 @@ namespace System.ServiceModel.Channels
         protected internal override async Task OnOpenAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await OnOpenCoreAsync(timeoutHelper.RemainingTime());
-            await base.OnOpenAsync(timeoutHelper.RemainingTime());
+            await OnOpenCoreAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await base.OnOpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             SetBufferManager();
         }
 
@@ -288,8 +288,8 @@ namespace System.ServiceModel.Channels
                     typeof(TChannel) == typeof(IRequestChannel),
                     timeoutHelper.RemainingTime());
                 OnProtocolCreationComplete(securityProtocol);
-                await SecurityProtocol.OpenAsync(timeoutHelper.RemainingTime());
-                await base.OnOpenAsync(timeoutHelper.RemainingTime());
+                await SecurityProtocol.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                await base.OnOpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             private void EnableChannelBindingSupport()
@@ -364,14 +364,14 @@ namespace System.ServiceModel.Channels
                 ThrowIfFaulted();
                 ThrowIfDisposedOrNotOpen(message);
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                message = await SecurityProtocol.SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime());
+                message = await SecurityProtocol.SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 if (InnerChannel is IAsyncOutputChannel asyncOutputChannel)
                 {
-                    await asyncOutputChannel.SendAsync(message, timeoutHelper.RemainingTime());
+                    await asyncOutputChannel.SendAsync(message, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
                 else
                 {
-                    await Task.Factory.FromAsync(InnerChannel.BeginSend, InnerChannel.EndSend, message, timeoutHelper.RemainingTime(), null);
+                    await Task.Factory.FromAsync(InnerChannel.BeginSend, InnerChannel.EndSend, message, timeoutHelper.RemainingTime(), null).ConfigureAwait(false);
                 }
             }
 
@@ -467,8 +467,8 @@ namespace System.ServiceModel.Channels
                 ThrowIfDisposedOrNotOpen(message);
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
                 SecurityProtocolCorrelationState correlationState;
-                (correlationState, message) = await SecurityProtocol.SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime(), null);
-                Message reply = await Task.Factory.FromAsync(InnerChannel.BeginRequest, InnerChannel.EndRequest, message, timeoutHelper.RemainingTime(), null);
+                (correlationState, message) = await SecurityProtocol.SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime(), null).ConfigureAwait(false);
+                Message reply = await Task.Factory.FromAsync(InnerChannel.BeginRequest, InnerChannel.EndRequest, message, timeoutHelper.RemainingTime(), null).ConfigureAwait(false);
 
                 return ProcessReply(reply, correlationState, timeoutHelper.RemainingTime());
             }
@@ -476,7 +476,7 @@ namespace System.ServiceModel.Channels
             private async Task<Message> RequestAsyncInternal(Message message, TimeSpan timeout)
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                return await RequestAsync(message, timeout);
+                return await RequestAsync(message, timeout).ConfigureAwait(false);
             }
 
             public Message Request(Message message, TimeSpan timeout)
@@ -616,11 +616,11 @@ namespace System.ServiceModel.Channels
                 Message message;
                 if (InnerDuplexChannel is IAsyncDuplexChannel asyncDuplexChannel)
                 {
-                    (success, message) = await asyncDuplexChannel.TryReceiveAsync(timeoutHelper.RemainingTime());
+                    (success, message) = await asyncDuplexChannel.TryReceiveAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
                 else
                 {
-                    (success, message) = await TaskHelpers.FromAsync<TimeSpan, bool, Message>(InnerDuplexChannel.BeginTryReceive, InnerDuplexChannel.EndTryReceive, timeout, null);
+                    (success, message) = await TaskHelpers.FromAsync<TimeSpan, bool, Message>(InnerDuplexChannel.BeginTryReceive, InnerDuplexChannel.EndTryReceive, timeout, null).ConfigureAwait(false);
                 }
                 if (success)
                 {

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -1308,12 +1308,12 @@ namespace System.ServiceModel.Channels
 
             if (_closeBinder)
             {
-                await CloseOtherAsync(InnerChannel, timeoutHelper.RemainingTime());
+                await CloseOtherAsync(InnerChannel, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             if (CloseFactory)
             {
-                await CloseOtherAsync(Factory, timeoutHelper.RemainingTime());
+                await CloseOtherAsync(Factory, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             CleanupChannelCollections();
@@ -1348,7 +1348,7 @@ namespace System.ServiceModel.Channels
 
             if (_openBinder)
             {
-                await OpenOtherAsync(InnerChannel, timeout);
+                await OpenOtherAsync(InnerChannel, timeout).ConfigureAwait(false);
             }
 
             BindDuplexCallbacks();
@@ -1612,7 +1612,7 @@ namespace System.ServiceModel.Channels
                 // Only want to call Close if it is in the Opened state
                 if (State == CommunicationState.Opened)
                 {
-                    await ((IAsyncCommunicationObject)this).CloseAsync(DefaultCloseTimeout);
+                    await ((IAsyncCommunicationObject)this).CloseAsync(DefaultCloseTimeout).ConfigureAwait(false);
                 }
                 // Anything not closed by this point should be aborted
                 if (State != CommunicationState.Closed)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ServiceChannelFactory.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ServiceChannelFactory.cs
@@ -410,7 +410,7 @@ namespace System.ServiceModel.Channels
                     channel = _channelsList[0];
                 }
 
-                await CloseOtherAsync(channel, timeoutHelper.RemainingTime());
+                await CloseOtherAsync(channel, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
         }
 
@@ -497,14 +497,14 @@ namespace System.ServiceModel.Channels
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
                 if (_isSynchronousClose)
                 {
-                    await TaskHelpers.CallActionAsync(base.OnClose, timeoutHelper.RemainingTime());
+                    await TaskHelpers.CallActionAsync(base.OnClose, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
                 else
                 {
-                    await Task.Factory.FromAsync(base.OnBeginClose, base.OnEndClose, timeoutHelper.RemainingTime(), TaskCreationOptions.None);
+                    await Task.Factory.FromAsync(base.OnBeginClose, base.OnEndClose, timeoutHelper.RemainingTime(), TaskCreationOptions.None).ConfigureAwait(false);
                 }
 
-                await CloseOtherAsync(InnerChannelFactory, timeoutHelper.RemainingTime());
+                await CloseOtherAsync(InnerChannelFactory, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
         }
 

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/TextMessageEncoder.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/TextMessageEncoder.cs
@@ -547,7 +547,7 @@ namespace System.ServiceModel.Channels
             private async Task WriteMessageAsyncInternal(Message message, Stream stream)
             {
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                await WriteMessageAsync(message, stream);
+                await WriteMessageAsync(message, stream).ConfigureAwait(false);
             }
 
             public override async ValueTask WriteMessageAsync(Message message, Stream stream)
@@ -575,16 +575,16 @@ namespace System.ServiceModel.Channels
                 XmlDictionaryWriter xmlWriter = TakeStreamedWriter(stream);
                 if (_optimizeWriteForUTF8)
                 {
-                    await message.WriteMessageAsync(xmlWriter);
+                    await message.WriteMessageAsync(xmlWriter).ConfigureAwait(false);
                 }
                 else
                 {
                     xmlWriter.WriteStartDocument();
-                    await message.WriteMessageAsync(xmlWriter);
+                    await message.WriteMessageAsync(xmlWriter).ConfigureAwait(false);
                     xmlWriter.WriteEndDocument();
                 }
 
-                await xmlWriter.FlushAsync();
+                await xmlWriter.FlushAsync().ConfigureAwait(false);
                 ReturnStreamedWriter(xmlWriter);
 
                 if (WcfEventSource.Instance.StreamedMessageWrittenByEncoderIsEnabled())

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/TimeoutStream.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/TimeoutStream.cs
@@ -54,21 +54,21 @@ namespace System.ServiceModel.Channels
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             // Supporting a passed in cancellationToken as well as honoring the timeout token in this class would require
-            // creating a linked token source on every call which is extra allocation and needs disposal. As this is an 
+            // creating a linked token source on every call which is extra allocation and needs disposal. As this is an
             // internal classs, it's okay to add this extra constraint to usage of this method.
             Fx.Assert(!cancellationToken.CanBeCanceled, "cancellationToken shouldn't be cancellable");
-            var cancelToken = await _timeoutHelper.GetCancellationTokenAsync();
-            return await base.ReadAsync(buffer, offset, count, cancelToken);
+            var cancelToken = await _timeoutHelper.GetCancellationTokenAsync().ConfigureAwait(false);
+            return await base.ReadAsync(buffer, offset, count, cancelToken).ConfigureAwait(false);
         }
 
         public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             // Supporting a passed in cancellationToken as well as honoring the timeout token in this class would require
-            // creating a linked token source on every call which is extra allocation and needs disposal. As this is an 
+            // creating a linked token source on every call which is extra allocation and needs disposal. As this is an
             // internal classs, it's okay to add this extra constraint to usage of this method.
             Fx.Assert(!cancellationToken.CanBeCanceled, "cancellationToken shouldn't be cancellable");
-            var cancelToken = await _timeoutHelper.GetCancellationTokenAsync();
-            return await base.ReadAsync(buffer, cancelToken);
+            var cancelToken = await _timeoutHelper.GetCancellationTokenAsync().ConfigureAwait(false);
+            return await base.ReadAsync(buffer, cancelToken).ConfigureAwait(false);
         }
 
         private async ValueTask<int> ReadAsyncInternal(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -76,7 +76,7 @@ namespace System.ServiceModel.Channels
             await TaskHelpers.EnsureDefaultTaskScheduler();
             // Using the ReadAsync overload which takes Memory<byte> as it returns a ValueTask which avoids
             // allocation when the read completes synchronously.
-            return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken);
+            return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         public override void Write(byte[] buffer, int offset, int count)
@@ -97,21 +97,21 @@ namespace System.ServiceModel.Channels
         public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             // Supporting a passed in cancellationToken as well as honoring the timeout token in this class would require
-            // creating a linked token source on every call which is extra allocation and needs disposal. As this is an 
+            // creating a linked token source on every call which is extra allocation and needs disposal. As this is an
             // internal classs, it's okay to add this extra constraint to usage of this method.
             Fx.Assert(!cancellationToken.CanBeCanceled, "cancellationToken shouldn't be cancellable");
-            var cancelToken = await _timeoutHelper.GetCancellationTokenAsync();
-            await base.WriteAsync(buffer, offset, count, cancelToken);
+            var cancelToken = await _timeoutHelper.GetCancellationTokenAsync().ConfigureAwait(false);
+            await base.WriteAsync(buffer, offset, count, cancelToken).ConfigureAwait(false);
         }
 
         public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             // Supporting a passed in cancellationToken as well as honoring the timeout token in this class would require
-            // creating a linked token source on every call which is extra allocation and needs disposal. As this is an 
+            // creating a linked token source on every call which is extra allocation and needs disposal. As this is an
             // internal classs, it's okay to add this extra constraint to usage of this method.
             Fx.Assert(!cancellationToken.CanBeCanceled, "cancellationToken shouldn't be cancellable");
-            var cancelToken = await _timeoutHelper.GetCancellationTokenAsync();
-            await base.WriteAsync(buffer, cancelToken);
+            var cancelToken = await _timeoutHelper.GetCancellationTokenAsync().ConfigureAwait(false);
+            await base.WriteAsync(buffer, cancelToken).ConfigureAwait(false);
         }
 
         private async ValueTask WriteAsyncInternal(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -119,7 +119,7 @@ namespace System.ServiceModel.Channels
             await TaskHelpers.EnsureDefaultTaskScheduler();
             // Using the ReadAsync overload which takes Memory<byte> as it returns a ValueTask which avoids
             // allocation when the read completes synchronously.
-            await WriteAsync(new Memory<byte>(buffer, offset, count), cancellationToken);
+            await WriteAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/TransmissionStrategy.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/TransmissionStrategy.cs
@@ -185,7 +185,7 @@ namespace System.ServiceModel.Channels
                 throw Fx.AssertAndThrow("Last message supported only in February 2005.");
             }
 
-            (MessageAttemptInfo attemptInfo, _) = await InternalAddAsync(message, true, timeout, state);
+            (MessageAttemptInfo attemptInfo, _) = await InternalAddAsync(message, true, timeout, state).ConfigureAwait(false);
             return attemptInfo;
         }
 
@@ -436,7 +436,7 @@ namespace System.ServiceModel.Channels
                 _waitQueue.Enqueue(adder);
             }
 
-            attemptInfo = await adder.WaitAsync(timeout);
+            attemptInfo = await adder.WaitAsync(timeout).ConfigureAwait(false);
             return (attemptInfo, true);
         }
 
@@ -776,7 +776,7 @@ namespace System.ServiceModel.Channels
 
             public async Task<MessageAttemptInfo> WaitAsync(TimeSpan timeout)
             {
-                if (!await _tcs.Task.AwaitWithTimeout(timeout))
+                if (!await _tcs.Task.AwaitWithTimeout(timeout).ConfigureAwait(false))
                 {
                     if (_strategy.RemoveAdder(this) && _exception == null)
                         _exception = new TimeoutException(SRP.Format(SRP.TimeoutOnAddToWindow, timeout));

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/TransportSecurityHelpers.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/TransportSecurityHelpers.cs
@@ -20,7 +20,7 @@ namespace System.ServiceModel.Channels
         public static async ValueTask<(NetworkCredential credential, TokenImpersonationLevel impersonationLevel, AuthenticationLevel authenticationLevel)> GetSspiCredentialAsync(
             SecurityTokenProviderContainer tokenProvider, TimeSpan timeout)
         {
-            var result = await GetSspiCredentialCoreAsync(tokenProvider.TokenProvider as SspiSecurityTokenProvider, timeout);
+            var result = await GetSspiCredentialCoreAsync(tokenProvider.TokenProvider as SspiSecurityTokenProvider, timeout).ConfigureAwait(false);
             AuthenticationLevel authenticationLevel =  result.allowNtlm ? AuthenticationLevel.MutualAuthRequested : AuthenticationLevel.MutualAuthRequired;
             return (result.credential, result.impersonationLevel, authenticationLevel);
         }
@@ -37,7 +37,7 @@ namespace System.ServiceModel.Channels
 
             if (tokenProvider != null)
             {
-                SspiSecurityToken token = await TransportSecurityHelpers.GetTokenAsync<SspiSecurityToken>(tokenProvider, timeout);
+                SspiSecurityToken token = await TransportSecurityHelpers.GetTokenAsync<SspiSecurityToken>(tokenProvider, timeout).ConfigureAwait(false);
                 if (token != null)
                 {
                     result.extractGroupsForWindowsAccounts = token.ExtractGroupsForWindowsAccounts;
@@ -137,7 +137,7 @@ namespace System.ServiceModel.Channels
         private static async Task<T> GetTokenAsync<T>(SecurityTokenProvider tokenProvider, TimeSpan timeout)
             where T : SecurityToken
         {
-            SecurityToken result = await tokenProvider.GetTokenAsync(timeout);
+            SecurityToken result = await tokenProvider.GetTokenAsync(timeout).ConfigureAwait(false);
             if ((result != null) && !(result is T))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SRP.Format(
@@ -152,7 +152,7 @@ namespace System.ServiceModel.Channels
 
             if (tokenProvider != null && tokenProvider.TokenProvider != null)
             {
-                UserNameSecurityToken token = await GetTokenAsync<UserNameSecurityToken>(tokenProvider.TokenProvider, timeout);
+                UserNameSecurityToken token = await GetTokenAsync<UserNameSecurityToken>(tokenProvider.TokenProvider, timeout).ConfigureAwait(false);
                 if (token != null)
                 {
                     result = new NetworkCredential(token.UserName, token.Password);

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/ClientBase.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/ClientBase.cs
@@ -316,10 +316,10 @@ namespace System.ServiceModel
             await TaskHelpers.EnsureDefaultTaskScheduler();
             if (!_useCachedFactory)
             {
-                await GetChannelFactory().OpenHelperAsync(timeoutHelper.RemainingTime());
+                await GetChannelFactory().OpenHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
-            await InnerChannel.OpenHelperAsync(timeoutHelper.RemainingTime());
+            await InnerChannel.OpenHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         public void Abort()
@@ -377,7 +377,7 @@ namespace System.ServiceModel
                 await TaskHelpers.EnsureDefaultTaskScheduler();
                 if (_channel != null)
                 {
-                    await InnerChannel.CloseHelperAsync(timeoutHelper.RemainingTime());
+                    await InnerChannel.CloseHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
 
                 if (!_channelFactoryRefReleased)
@@ -404,7 +404,7 @@ namespace System.ServiceModel
                         }
                         else
                         {
-                            await GetChannelFactory().CloseHelperAsync(timeoutHelper.RemainingTime());
+                            await GetChannelFactory().CloseHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                         }
                     }
                 }
@@ -476,7 +476,7 @@ namespace System.ServiceModel
                 // Only want to call Close if it is in the Opened state
                 if (State == CommunicationState.Opened)
                 {
-                    await CloseAsync();
+                    await CloseAsync().ConfigureAwait(false);
                 }
                 // Anything not closed by this point should be aborted
                 if (State != CommunicationState.Closed)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/ListenerHandler.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/ListenerHandler.cs
@@ -71,7 +71,7 @@ namespace System.ServiceModel.Dispatcher
             ChannelDispatcher.Channels.CloseInput();
 
             // Start closing existing channels
-            await CloseChannelsAsync(timeoutHelper.RemainingTime());
+            await CloseChannelsAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         protected internal override Task OnOpenAsync(TimeSpan timeout)
@@ -147,11 +147,11 @@ namespace System.ServiceModel.Dispatcher
                     if (channel is ISessionChannel<IDuplexSession>)
                     {
                         IDuplexSession duplexSession = ((ISessionChannel<IDuplexSession>)channel).Session;
-                        await Task.Factory.FromAsync(duplexSession.BeginCloseOutputSession, duplexSession.EndCloseOutputSession, timeout, null);
+                        await Task.Factory.FromAsync(duplexSession.BeginCloseOutputSession, duplexSession.EndCloseOutputSession, timeout, null).ConfigureAwait(false);
                     }
                     else
                     {
-                        await channel.CloseHelperAsync(timeout);
+                        await channel.CloseHelperAsync(timeout).ConfigureAwait(false);
                     }
                 }
             }
@@ -211,7 +211,7 @@ namespace System.ServiceModel.Dispatcher
             {
                 closeTasks[index] = CloseChannelAsync(channels[index], timeoutHelper.RemainingTime());
             }
-            await Task.WhenAll(closeTasks);
+            await Task.WhenAll(closeTasks).ConfigureAwait(false);
         }
 
         private void Dispatch()

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/OperationFormatter.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/OperationFormatter.cs
@@ -379,11 +379,11 @@ namespace System.ServiceModel.Dispatcher
 
             if (streamFormatter != null)
             {
-                await streamFormatter.SerializeAsync(writer, parameters, returnValue);
+                await streamFormatter.SerializeAsync(writer, parameters, returnValue).ConfigureAwait(false);
                 return;
             }
 
-            await SerializeBodyAsync(writer, version, RequestAction, messageDescription, returnValue, parameters, isRequest);
+            await SerializeBodyAsync(writer, version, RequestAction, messageDescription, returnValue, parameters, isRequest).ConfigureAwait(false);
         }
 
         private IAsyncResult BeginSerializeBodyContents(XmlDictionaryWriter writer, MessageVersion version, object[] parameters, object returnValue, bool isRequest,

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/StreamFormatter.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/StreamFormatter.cs
@@ -63,10 +63,10 @@ namespace System.ServiceModel.Dispatcher
 
         internal async Task SerializeAsync(XmlDictionaryWriter writer, object[] parameters, object returnValue)
         {
-            Stream streamValue = await GetStreamAndWriteStartWrapperIfNecessaryAsync(writer, parameters, returnValue);
+            Stream streamValue = await GetStreamAndWriteStartWrapperIfNecessaryAsync(writer, parameters, returnValue).ConfigureAwait(false);
             var streamProvider = new OperationStreamProvider(streamValue);
-            await writer.WriteValueAsync(streamProvider);
-            await WriteEndWrapperIfNecessaryAsync(writer);
+            await writer.WriteValueAsync(streamProvider).ConfigureAwait(false);
+            await WriteEndWrapperIfNecessaryAsync(writer).ConfigureAwait(false);
         }
 
         private Stream GetStreamAndWriteStartWrapperIfNecessary(XmlDictionaryWriter writer, object[] parameters, object returnValue)
@@ -96,10 +96,10 @@ namespace System.ServiceModel.Dispatcher
 
             if (WrapperName != null)
             {
-                await writer.WriteStartElementAsync(null, WrapperName, WrapperNamespace);
+                await writer.WriteStartElementAsync(null, WrapperName, WrapperNamespace).ConfigureAwait(false);
             }
 
-            await writer.WriteStartElementAsync(null, PartName, PartNamespace);
+            await writer.WriteStartElementAsync(null, PartName, PartNamespace).ConfigureAwait(false);
             return streamValue;
         }
 
@@ -114,10 +114,10 @@ namespace System.ServiceModel.Dispatcher
 
         private async Task WriteEndWrapperIfNecessaryAsync(XmlDictionaryWriter writer)
         {
-            await writer.WriteEndElementAsync();
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
             if (WrapperName != null)
             {
-                await writer.WriteEndElementAsync();
+                await writer.WriteEndElementAsync().ConfigureAwait(false);
             }
         }
 
@@ -316,7 +316,7 @@ namespace System.ServiceModel.Dispatcher
                 {
                     if (_bufferedReadStream != null)
                     {
-                        await _bufferedReadStream.PreReadBufferAsync(cancellationToken);
+                        await _bufferedReadStream.PreReadBufferAsync(cancellationToken).ConfigureAwait(false);
                     }
 
                     return Read(buffer, offset, count);

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/TaskMethodInvoker.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/TaskMethodInvoker.cs
@@ -217,7 +217,7 @@ namespace System.ServiceModel.Dispatcher
                     if (returnValueTask != null)
                     {
                         // Only return once the task has completed
-                        await returnValueTask;
+                        await returnValueTask.ConfigureAwait(false);
                     }
 
                     callSucceeded = true;

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/InitiatorSessionSymmetricTransportSecurityProtocol.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/InitiatorSessionSymmetricTransportSecurityProtocol.cs
@@ -129,7 +129,7 @@ namespace System.ServiceModel.Security
             SecurityTokenParameters tokenParameters;
             GetTokensForOutgoingMessages(out signingToken, out sourceToken, out tokenParameters);
             IList<SupportingTokenSpecification> supportingTokens;
-            supportingTokens = await TryGetSupportingTokensAsync(SecurityProtocolFactory, Target, Via, message, timeout);
+            supportingTokens = await TryGetSupportingTokensAsync(SecurityProtocolFactory, Target, Via, message, timeout).ConfigureAwait(false);
             SetupDelayedSecurityExecution(actor, ref message, signingToken, sourceToken, tokenParameters, supportingTokens);
             return message;
         }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/IssuanceTokenProviderBase.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/IssuanceTokenProviderBase.cs
@@ -447,11 +447,11 @@ namespace System.ServiceModel.Security
             int legs = 1;
             try
             {
-                negotiationState = await CreateNegotiationStateAsync(_targetAddress, _via, timeoutHelper.RemainingTime());
+                negotiationState = await CreateNegotiationStateAsync(_targetAddress, _via, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 InitializeNegotiationState(negotiationState);
-                await InitializeChannelFactoriesAsync(negotiationState.RemoteAddress, timeoutHelper.RemainingTime());
+                await InitializeChannelFactoriesAsync(negotiationState.RemoteAddress, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 rstChannel = CreateClientChannel(negotiationState.RemoteAddress, _via);
-                await rstChannel.OpenAsync(timeoutHelper.RemainingTime());
+                await rstChannel.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 Message nextOutgoingMessage = null;
                 Message incomingMessage = null;
                 SecurityToken serviceToken = null;
@@ -468,7 +468,7 @@ namespace System.ServiceModel.Security
                         using (nextOutgoingMessage)
                         {
                             timeLeft = timeoutHelper.RemainingTime();
-                            incomingMessage = await rstChannel.RequestAsync(nextOutgoingMessage, timeLeft);
+                            incomingMessage = await rstChannel.RequestAsync(nextOutgoingMessage, timeLeft).ConfigureAwait(false);
                             if (incomingMessage == null)
                             {
                                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new CommunicationException(SRP.FailToReceiveReplyFromNegotiation));

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/NegotiationTokenProvider.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/NegotiationTokenProvider.cs
@@ -78,11 +78,11 @@ namespace System.ServiceModel.Security
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             if (_rstChannelFactory != null)
             {
-                await _rstChannelFactory.CloseHelperAsync(timeout);
+                await _rstChannelFactory.CloseHelperAsync(timeout).ConfigureAwait(false);
                 _rstChannelFactory = null;
             }
 
-            await base.OnCloseAsync(timeoutHelper.RemainingTime());
+            await base.OnCloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         public override void OnAbort()
@@ -103,8 +103,8 @@ namespace System.ServiceModel.Security
             }
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             SetupRstChannelFactory();
-            await _rstChannelFactory.OpenHelperAsync(timeout);
-            await base.OnOpenAsync(timeoutHelper.RemainingTime());
+            await _rstChannelFactory.OpenHelperAsync(timeout).ConfigureAwait(false);
+            await base.OnOpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         protected abstract IChannelFactory<IAsyncRequestChannel> GetNegotiationChannelFactory(IChannelFactory<IAsyncRequestChannel> transportChannelFactory, ChannelBuilder channelBuilder);

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
@@ -146,7 +146,7 @@ namespace System.ServiceModel.Security
             switch (_state)
             {
                 case BodyState.Created:
-                    await InnerMessage.WriteBodyContentsAsync(writer);
+                    await InnerMessage.WriteBodyContentsAsync(writer).ConfigureAwait(false);
                     return;
                 case BodyState.Signed:
                 case BodyState.EncryptedThenSigned:
@@ -154,7 +154,7 @@ namespace System.ServiceModel.Security
                     reader.ReadStartElement();
                     while (reader.NodeType != XmlNodeType.EndElement)
                     {
-                        await writer.WriteNodeAsync(reader, false);
+                        await writer.WriteNodeAsync(reader, false).ConfigureAwait(false);
                     }
 
                     reader.ReadEndElement();
@@ -254,7 +254,7 @@ namespace System.ServiceModel.Security
 
             _securityHeader.CompleteSecurityApplication();
             _securityHeader.WriteHeader(writer, Version);
-            await writer.WriteEndElementAsync();
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
 
             if (_fullBodyFragment != null)
             {
@@ -271,7 +271,7 @@ namespace System.ServiceModel.Security
                     OnWriteStartBody(writer);
                 }
 
-                await OnWriteBodyContentsAsync(writer);
+                await OnWriteBodyContentsAsync(writer).ConfigureAwait(false);
 
                 if (_endBodyFragment != null)
                 {
@@ -283,7 +283,7 @@ namespace System.ServiceModel.Security
                 }
             }
 
-            await writer.WriteEndElementAsync();
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
         }
 
         private void AttachChannelBindingTokenIfFound()

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecurityChannel.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecurityChannel.cs
@@ -63,10 +63,10 @@ namespace System.ServiceModel.Security
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             if (_securityProtocol != null)
             {
-                await _securityProtocol.CloseAsync(false, timeoutHelper.RemainingTime());
+                await _securityProtocol.CloseAsync(false, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
-            await base.OnCloseAsync(timeoutHelper.RemainingTime());
+            await base.OnCloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         protected void ThrowIfDisposedOrNotOpen(Message message)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecurityProtocol.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecurityProtocol.cs
@@ -272,7 +272,7 @@ namespace System.ServiceModel.Security
                     }
                     foreach (SupportingTokenProviderSpecification spec in scopedProviders)
                     {
-                        await SecurityUtils.OpenTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime());
+                        await SecurityUtils.OpenTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                         if (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
                         {
                             if (spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey)
@@ -337,7 +337,7 @@ namespace System.ServiceModel.Security
                         SecurityProtocolFactory.ExpectSupportingTokens = true;
                         foreach (SupportingTokenProviderSpecification tokenProviderSpec in ChannelSupportingTokenProviderSpecification)
                         {
-                            await SecurityUtils.OpenTokenProviderIfRequiredAsync(tokenProviderSpec.TokenProvider, timeoutHelper.RemainingTime());
+                            await SecurityUtils.OpenTokenProviderIfRequiredAsync(tokenProviderSpec.TokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                             if (tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
                             {
                                 if (tokenProviderSpec.TokenParameters.RequireDerivedKeys && !tokenProviderSpec.TokenParameters.HasAsymmetricKey)
@@ -351,7 +351,7 @@ namespace System.ServiceModel.Security
                     }
                 }
                 // create a merged map of the per operation supporting tokens
-                await MergeSupportingTokenProvidersAsync(timeoutHelper.RemainingTime());
+                await MergeSupportingTokenProvidersAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
         }
 
@@ -394,7 +394,7 @@ namespace System.ServiceModel.Security
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
                 foreach (SupportingTokenProviderSpecification spec in ChannelSupportingTokenProviderSpecification)
                 {
-                    await SecurityUtils.CloseTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime());
+                    await SecurityUtils.CloseTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
 
                 foreach (string action in ScopedSupportingTokenProviderSpecification.Keys)
@@ -402,7 +402,7 @@ namespace System.ServiceModel.Security
                     ICollection<SupportingTokenProviderSpecification> supportingProviders = ScopedSupportingTokenProviderSpecification[action];
                     foreach (SupportingTokenProviderSpecification spec in supportingProviders)
                     {
-                        await SecurityUtils.CloseTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime());
+                        await SecurityUtils.CloseTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     }
                 }
             }
@@ -511,7 +511,7 @@ namespace System.ServiceModel.Security
                 {
                     SupportingTokenProviderSpecification spec = supportingTokenProviders[i];
                     SecurityToken supportingToken;
-                    supportingToken = await spec.TokenProvider.GetTokenAsync(timeoutHelper.RemainingTime());
+                    supportingToken = await spec.TokenProvider.GetTokenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
                     supportingTokens.Add(new SupportingTokenSpecification(supportingToken, EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance, spec.SecurityTokenAttachmentMode, spec.TokenParameters));
                 }
@@ -595,7 +595,7 @@ namespace System.ServiceModel.Security
 
             try
             {
-                token = await provider.GetTokenAsync(timeout);
+                token = await provider.GetTokenAsync(timeout).ConfigureAwait(false);
             }
             catch (SecurityTokenException exception)
             {
@@ -614,7 +614,7 @@ namespace System.ServiceModel.Security
         // subclasses that offer correlation should override this version
         public virtual async Task<(SecurityProtocolCorrelationState, Message)> SecureOutgoingMessageAsync(Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
         {
-            return (null, await SecureOutgoingMessageAsync(message, timeout));
+            return (null, await SecureOutgoingMessageAsync(message, timeout).ConfigureAwait(false));
         }
 
         protected virtual void OnOutgoingMessageSecured(Message securedMessage)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
@@ -446,8 +446,8 @@ namespace System.ServiceModel.Security
                     Fx.Assert("Security protocol must be IInitiatorSecuritySessionProtocol.");
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SRP.Format(SRP.ProtocolMisMatch, nameof(IInitiatorSecuritySessionProtocol), GetType().ToString())));
                 }
-                await _securityProtocol.OpenAsync(timeoutHelper.RemainingTime());
-                await ChannelBinder.OpenAsync(timeoutHelper.RemainingTime());
+                await _securityProtocol.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                await ChannelBinder.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 InitializeSecurityState(sessionToken);
             }
 
@@ -479,14 +479,14 @@ namespace System.ServiceModel.Security
             {
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
                 SetupSessionTokenProvider();
-                await SecurityUtils.OpenTokenProviderIfRequiredAsync(_sessionTokenProvider, timeoutHelper.RemainingTime());
+                await SecurityUtils.OpenTokenProviderIfRequiredAsync(_sessionTokenProvider, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
                     ServiceModelActivity.CreateBoundedActivity() : null)
                 {
-                    SecurityToken sessionToken = await _sessionTokenProvider.GetTokenAsync(timeoutHelper.RemainingTime());
+                    SecurityToken sessionToken = await _sessionTokenProvider.GetTokenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     // Token was issued, do send cancel on close;
                     SendCloseHandshake = true;
-                    await OpenCoreAsync(sessionToken, timeoutHelper.RemainingTime());
+                    await OpenCoreAsync(sessionToken, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
             }
 
@@ -621,8 +621,8 @@ namespace System.ServiceModel.Security
                 Message closeMessage = PrepareCloseMessage();
                 try
                 {
-                    (closeCorrelationState, closeMessage) = await _securityProtocol.SecureOutgoingMessageAsync(closeMessage, timeoutHelper.RemainingTime(), null);
-                    await ChannelBinder.SendAsync(closeMessage, timeoutHelper.RemainingTime());
+                    (closeCorrelationState, closeMessage) = await _securityProtocol.SecureOutgoingMessageAsync(closeMessage, timeoutHelper.RemainingTime(), null).ConfigureAwait(false);
+                    await ChannelBinder.SendAsync(closeMessage, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -641,8 +641,8 @@ namespace System.ServiceModel.Security
                 {
                     message = _closeResponse;
                     SecurityProtocolCorrelationState dummy;
-                    (dummy, message) = await _securityProtocol.SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime(), null);
-                    await ChannelBinder.SendAsync(message, timeoutHelper.RemainingTime());
+                    (dummy, message) = await _securityProtocol.SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime(), null).ConfigureAwait(false);
+                    await ChannelBinder.SendAsync(message, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -1025,7 +1025,7 @@ namespace System.ServiceModel.Security
                         using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
                             ServiceModelActivity.CreateBoundedActivity() : null)
                         {
-                            SecurityToken renewedToken = await _sessionTokenProvider.RenewTokenAsync(timeout, _currentSessionToken);
+                            SecurityToken renewedToken = await _sessionTokenProvider.RenewTokenAsync(timeout, _currentSessionToken).ConfigureAwait(false);
                             UpdateSessionTokens(renewedToken);
                         }
                     }
@@ -1040,7 +1040,7 @@ namespace System.ServiceModel.Security
                 }
                 else
                 {
-                    await _keyRenewalCompletedEvent.WaitAsync(timeout);
+                    await _keyRenewalCompletedEvent.WaitAsync(timeout).ConfigureAwait(false);
                     lock (ThisLock)
                     {
                         if (IsKeyRenewalNeeded())
@@ -1069,9 +1069,9 @@ namespace System.ServiceModel.Security
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
                 if (doKeyRenewal)
                 {
-                    await RenewKeyAsync(timeoutHelper.RemainingTime());
+                    await RenewKeyAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
-                return await _securityProtocol.SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime(), null);
+                return await _securityProtocol.SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime(), null).ConfigureAwait(false);
             }
 
             protected void VerifyIncomingMessage(ref Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
@@ -1099,7 +1099,7 @@ namespace System.ServiceModel.Security
                 {
                     if (ChannelBinder != null)
                     {
-                        await ChannelBinder.CloseAsync(timeoutHelper.RemainingTime());
+                        await ChannelBinder.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     }
                     if (_sessionTokenProvider != null)
                     {
@@ -1122,7 +1122,7 @@ namespace System.ServiceModel.Security
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
                 while (!_isInputClosed)
                 {
-                    (bool success, RequestContext requestContext) = await ChannelBinder.TryReceiveAsync(timeoutHelper.RemainingTime());
+                    (bool success, RequestContext requestContext) = await ChannelBinder.TryReceiveAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                     if (success)
                     {
                         if (requestContext == null)
@@ -1163,8 +1163,8 @@ namespace System.ServiceModel.Security
                     wasAborted = false;
                     try
                     {
-                        await CloseOutputSessionAsync(timeoutHelper.RemainingTime());
-                        bool sessionClosed = await _inputSessionClosedHandle.WaitAsync(timeoutHelper.RemainingTime(), false);
+                        await CloseOutputSessionAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                        bool sessionClosed = await _inputSessionClosedHandle.WaitAsync(timeoutHelper.RemainingTime(), false).ConfigureAwait(false);
                         return (sessionClosed, wasAborted);
                     }
                     catch (CommunicationObjectAbortedException)
@@ -1219,11 +1219,11 @@ namespace System.ServiceModel.Security
                     {
                         if (sendClose)
                         {
-                            return await SendCloseMessageAsync(timeout);
+                            return await SendCloseMessageAsync(timeout).ConfigureAwait(false);
                         }
                         else
                         {
-                            await SendCloseResponseMessageAsync(timeout);
+                            await SendCloseResponseMessageAsync(timeout).ConfigureAwait(false);
                             return null;
                         }
                     }
@@ -1264,7 +1264,7 @@ namespace System.ServiceModel.Security
                 if (SendCloseHandshake)
                 {
                     bool wasAborted, wasSessionClosed;
-                    (wasSessionClosed, wasAborted) = await CloseSessionAsync(timeout);
+                    (wasSessionClosed, wasAborted) = await CloseSessionAsync(timeout).ConfigureAwait(false);
                     if (wasAborted)
                     {
                         return;
@@ -1278,7 +1278,7 @@ namespace System.ServiceModel.Security
                     // wait for any concurrent output session close to finish
                     try
                     {
-                        if (!await _outputSessionCloseHandle.WaitAsync(timeoutHelper.RemainingTime(), false))
+                        if (!await _outputSessionCloseHandle.WaitAsync(timeoutHelper.RemainingTime(), false).ConfigureAwait(false))
                         {
                             throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SRP.Format(SRP.ClientSecurityOutputSessionCloseTimeout, timeoutHelper.OriginalTimeout)));
                         }
@@ -1296,7 +1296,7 @@ namespace System.ServiceModel.Security
                     }
                 }
 
-                await CloseCoreAsync(timeoutHelper.RemainingTime());
+                await CloseCoreAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             protected override void OnClose(TimeSpan timeout)
@@ -1444,9 +1444,9 @@ namespace System.ServiceModel.Security
             {
                 ThrowIfFaulted();
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                SecurityProtocolCorrelationState correlationState = await base.CloseOutputSessionAsync(timeoutHelper.RemainingTime());
+                SecurityProtocolCorrelationState correlationState = await base.CloseOutputSessionAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
-                Message message = await ReceiveInternalAsync(timeoutHelper.RemainingTime(), correlationState);
+                Message message = await ReceiveInternalAsync(timeoutHelper.RemainingTime(), correlationState).ConfigureAwait(false);
 
                 if (message != null)
                 {
@@ -1522,8 +1522,8 @@ namespace System.ServiceModel.Security
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
                 SecurityProtocolCorrelationState correlationState;
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                (correlationState, message) = await SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime());
-                Message reply = await ChannelBinder.RequestAsync(message, timeoutHelper.RemainingTime());
+                (correlationState, message) = await SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                Message reply = await ChannelBinder.RequestAsync(message, timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 return ProcessReply(reply, timeoutHelper.RemainingTime(), correlationState);
             }
         }
@@ -1614,7 +1614,7 @@ namespace System.ServiceModel.Security
             {
                 ThrowIfFaulted();
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                (bool wasDequeued, Message message) = await _queue.TryDequeueAsync(timeout);
+                (bool wasDequeued, Message message) = await _queue.TryDequeueAsync(timeout).ConfigureAwait(false);
                 if (message == null)
                 {
                     // the channel could have faulted, shutting down the input queue
@@ -1636,8 +1636,8 @@ namespace System.ServiceModel.Security
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
                 SecurityProtocolCorrelationState dummy;
                 await TaskHelpers.EnsureDefaultTaskScheduler();
-                (dummy, message) = await SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime());
-                await ChannelBinder.SendAsync(message, timeoutHelper.RemainingTime());
+                (dummy, message) = await SecureOutgoingMessageAsync(message, timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                await ChannelBinder.SendAsync(message, timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             public IAsyncResult BeginSend(Message message, AsyncCallback callback, object state) => SendAsync(message).ToApm(callback, state);
@@ -1662,7 +1662,7 @@ namespace System.ServiceModel.Security
                     }
                     try
                     {
-                        Message message = await ReceiveInternalAsync(TimeSpan.MaxValue, null);
+                        Message message = await ReceiveInternalAsync(TimeSpan.MaxValue, null).ConfigureAwait(false);
                         if (message != null)
                         {
                             ActionItem.Schedule(Fx.ThunkCallback<object>(state =>
@@ -1792,7 +1792,7 @@ namespace System.ServiceModel.Security
                     Exception pendingException = null;
                     try
                     {
-                        await _channel.CloseOutputSessionAsync(timeout);
+                        await _channel.CloseOutputSessionAsync(timeout).ConfigureAwait(false);
                     }
                     catch (CommunicationObjectAbortedException)
                     {

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecuritySessionSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SecuritySessionSecurityTokenProvider.cs
@@ -288,7 +288,7 @@ namespace System.ServiceModel.Security
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SRP.Format(SRP.SecurityAlgorithmSuiteNotSet, GetType())));
             }
             InitializeFactories();
-            await _rstChannelFactory.OpenHelperAsync(timeoutHelper.RemainingTime());
+            await _rstChannelFactory.OpenHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             _sctUri = StandardsManager.SecureConversationDriver.TokenTypeUri;
         }
 
@@ -310,7 +310,7 @@ namespace System.ServiceModel.Security
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             if (_rstChannelFactory != null)
             {
-                await _rstChannelFactory.CloseHelperAsync(timeoutHelper.RemainingTime());
+                await _rstChannelFactory.CloseHelperAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 _rstChannelFactory = null;
             }
             FreeCredentialsHandle();
@@ -506,7 +506,7 @@ namespace System.ServiceModel.Security
                 channel = CreateChannel(operation, target, via);
 
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                await channel.OpenAsync(timeoutHelper.RemainingTime());
+                await channel.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 object requestState;
                 GenericXmlSecurityToken issuedToken;
 
@@ -516,7 +516,7 @@ namespace System.ServiceModel.Security
 
                     TraceUtility.ProcessOutgoingMessage(requestMessage, eventTraceActivity);
 
-                    using (Message reply = await channel.RequestAsync(requestMessage, timeoutHelper.RemainingTime()))
+                    using (Message reply = await channel.RequestAsync(requestMessage, timeoutHelper.RemainingTime()).ConfigureAwait(false))
                     {
                         if (reply == null)
                         {
@@ -529,7 +529,7 @@ namespace System.ServiceModel.Security
                         ValidateKeySize(issuedToken);
                     }
                 }
-                await channel.CloseAsync(timeoutHelper.RemainingTime());
+                await channel.CloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 OnOperationSuccess(operation, target, issuedToken, currentToken);
                 return issuedToken;
             }
@@ -753,8 +753,8 @@ namespace System.ServiceModel.Security
 
             protected internal override async Task OnCloseAsync(TimeSpan timeout)
             {
-                await base.OnCloseAsync(timeout);
-                await _serviceChannelFactory.CloseHelperAsync(timeout);
+                await base.OnCloseAsync(timeout).ConfigureAwait(false);
+                await _serviceChannelFactory.CloseHelperAsync(timeout).ConfigureAwait(false);
             }
 
             protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SessionSymmetricTransportSecurityProtocolFactory.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/SessionSymmetricTransportSecurityProtocolFactory.cs
@@ -50,7 +50,7 @@ namespace System.ServiceModel.Security
 
         public override async Task OnOpenAsync(TimeSpan timeout)
         {
-            await base.OnOpenAsync(timeout);
+            await base.OnOpenAsync(timeout).ConfigureAwait(false);
             if (SecurityTokenParameters == null)
             {
                 OnPropertySettingsError(nameof(SecurityTokenParameters), true);

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
@@ -32,7 +32,7 @@ namespace System.ServiceModel.Security
             {
                 if (SecurityProtocolFactory.ActAsInitiator)
                 {
-                    message = await SecureOutgoingMessageAtInitiatorAsync(message, actor, timeout);
+                    message = await SecureOutgoingMessageAtInitiatorAsync(message, actor, timeout).ConfigureAwait(false);
                 }
                 else
                 {
@@ -51,7 +51,7 @@ namespace System.ServiceModel.Security
 
         protected virtual async Task<Message> SecureOutgoingMessageAtInitiatorAsync(Message message, string actor, TimeSpan timeout)
         {
-            IList<SupportingTokenSpecification> supportingTokens = await TryGetSupportingTokensAsync(SecurityProtocolFactory, Target, Via, message, timeout);
+            IList<SupportingTokenSpecification> supportingTokens = await TryGetSupportingTokensAsync(SecurityProtocolFactory, Target, Via, message, timeout).ConfigureAwait(false);
             SetUpDelayedSecurityExecution(ref message, actor, supportingTokens);
             return message;
         }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/ServiceChannelManager.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/ServiceChannelManager.cs
@@ -116,7 +116,7 @@ namespace System.ServiceModel
 
             if (activityWaiter != null)
             {
-                CommunicationWaitResult result = await activityWaiter.WaitAsync(timeout, false);
+                CommunicationWaitResult result = await activityWaiter.WaitAsync(timeout, false).ConfigureAwait(false);
                 if (Interlocked.Decrement(ref _activityWaiterCount) == 0)
                 {
                     activityWaiter.Dispose();
@@ -255,8 +255,8 @@ namespace System.ServiceModel
         protected override async Task OnCloseAsync(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await CloseInputAsync(timeoutHelper.RemainingTime());
-            await base.OnCloseAsync(timeoutHelper.RemainingTime());
+            await CloseInputAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            await base.OnCloseAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
         }
 
         protected override void OnEndClose(IAsyncResult result)

--- a/src/System.ServiceModel.UnixDomainSocket/src/System/ServiceModel/Channels/SocketConnection.cs
+++ b/src/System.ServiceModel.UnixDomainSocket/src/System/ServiceModel/Channels/SocketConnection.cs
@@ -191,7 +191,7 @@ namespace System.ServiceModel.Channels
                     restoreFlow = false;
                     ExecutionContext.RestoreFlow();
                 }
-                bytesRead = await resultTask;
+                bytesRead = await resultTask.ConfigureAwait(false);
                 abortRead = false;
                 if (WcfEventSource.Instance.SocketReadStopIsEnabled())
                 {
@@ -274,7 +274,7 @@ namespace System.ServiceModel.Channels
                     ExecutionContext.RestoreFlow();
                 }
 
-                await resultTask;
+                await resultTask.ConfigureAwait(false);
                 abortWrite = false;
             }
             catch (SocketException socketException)
@@ -333,7 +333,7 @@ namespace System.ServiceModel.Channels
                 // host to send a FIN back. A pending read on a socket will complete returning zero bytes when a FIN
                 // packet is received.
                 byte[] dummy = Fx.AllocateByteArray(1);
-                int bytesRead = await ReadCoreAsync(dummy, _readFinTimeout, true);
+                int bytesRead = await ReadCoreAsync(dummy, _readFinTimeout, true).ConfigureAwait(false);
 
                 if (bytesRead > 0)
                 {
@@ -351,7 +351,7 @@ namespace System.ServiceModel.Channels
 
             lock (ThisLock)
             {
-                // Abort could have been called on a separate thread and cleaned up 
+                // Abort could have been called on a separate thread and cleaned up
                 // our buffers/completion here
                 if (_closeState != CloseState.Closed)
                 {
@@ -777,7 +777,7 @@ namespace System.ServiceModel.Channels
                 AddressFamily addressFamily = AddressFamily.Unix;
                 socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.IP);
                 var endpoint = new UnixDomainSocketEndPoint(uriPath.LocalPath);
-                await socket.ConnectAsync(endpoint);
+                await socket.ConnectAsync(endpoint).ConfigureAwait(false);
                 return new SocketConnection(socket, _bufferSize);
             }
             catch
@@ -833,7 +833,7 @@ namespace System.ServiceModel.Channels
                 }
             }
         }
-      
+
         private static TimeoutException CreateTimeoutException(Uri uri, TimeSpan timeout, SocketException innerException)
         {
             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException("Timed out while connecting to Unix domain socket", innerException));
@@ -853,7 +853,7 @@ namespace System.ServiceModel.Channels
 
             try
             {
-                socketConnection = await CreateConnectionAsync(uri);
+                socketConnection = await CreateConnectionAsync(uri).ConfigureAwait(false);
             }
             catch (SocketException socketException)
             {


### PR DESCRIPTION
Apparently, the existing implementation does not account for applications with a synchronization context. Most methods lack ConfigureAwait calls, which causes continuations to capture the current synchronization context and resume execution on a context-specific thread.

This behavior is important for UI applications, where continuations may resume on the UI thread and, in certain scenarios (especially sync-over-async), can lead to deadlocks. For general-purpose library code, it is [recommended](https://devblogs.microsoft.com/dotnet/configureawait-faq/) to use ConfigureAwait(false) to avoid context capture and remain environment-agnostic.

This PR changes:
* ConfigureAwait(false) was added to all awaited asynchronous method calls, except in test projects.
* The solution was configured to treat missing ConfigureAwait usage as an error to prevent future omissions. This rule is enabled for all projects except tests.