### PR TITLE
[dotnet-svcutil] preserve enum numeric values in XmlSerializer codegen

### DIFF
--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/CodeExporter.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/CodeExporter.cs
@@ -250,7 +250,10 @@ namespace Microsoft.Xml.Serialization
             CodeNamespace.Types.Add(codeClass);
             for (int i = 0; i < mapping.Constants.Length; i++)
             {
-                ExportConstant(codeClass, mapping.Constants[i], type, mapping.IsFlags, 1L << i);
+                ConstantMapping constant = mapping.Constants[i];
+                long defaultValue = mapping.IsFlags ? (1L << i) : i;
+                bool shouldEmitValue = mapping.IsFlags || constant.Value != defaultValue;
+                ExportConstant(codeClass, constant, type, shouldEmitValue, constant.Value);
             }
             if (mapping.IsFlags)
             {

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/SoapSchemaImporter.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/SoapSchemaImporter.cs
@@ -639,6 +639,7 @@ namespace Microsoft.Xml.Serialization
                 throw new InvalidOperationException(string.Format(ResXml.XmlInvalidEnumContent, dataType.Content.GetType().Name, identifier));
 
             XmlSchemaSimpleTypeRestriction restriction = (XmlSchemaSimpleTypeRestriction)dataType.Content;
+            int enumIndex = 0;
 
             for (int i = 0; i < restriction.Facets.Count; i++)
             {
@@ -649,8 +650,9 @@ namespace Microsoft.Xml.Serialization
                 string constantName = CodeIdentifier.MakeValid(enumeration.Value);
                 constant.Name = constants.AddUnique(constantName, constant);
                 constant.XmlName = enumeration.Value;
-                long defaultValue = isList ? (1L << i) : i;
+                long defaultValue = isList ? (1L << enumIndex) : enumIndex;
                 constant.Value = TryGetDataContractEnumValue(enumeration.Annotation, out long enumValue) ? enumValue : defaultValue;
+                enumIndex++;
             }
             enumMapping.Constants = (ConstantMapping[])constants.ToArray(typeof(ConstantMapping));
             if (isList && enumMapping.Constants.Length > 63)

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/SoapSchemaImporter.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/SoapSchemaImporter.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Xml.Serialization
     using Microsoft.Xml.Schema;
     using System.Collections;
     using System.ComponentModel;
+    using System.Globalization;
     using System.Reflection;
     using System.Diagnostics;
     using Microsoft.CodeDom.Compiler;
@@ -648,7 +649,8 @@ namespace Microsoft.Xml.Serialization
                 string constantName = CodeIdentifier.MakeValid(enumeration.Value);
                 constant.Name = constants.AddUnique(constantName, constant);
                 constant.XmlName = enumeration.Value;
-                constant.Value = i;
+                long defaultValue = isList ? (1L << i) : i;
+                constant.Value = TryGetDataContractEnumValue(enumeration.Annotation, out long enumValue) ? enumValue : defaultValue;
             }
             enumMapping.Constants = (ConstantMapping[])constants.ToArray(typeof(ConstantMapping));
             if (isList && enumMapping.Constants.Length > 63)
@@ -663,6 +665,39 @@ namespace Microsoft.Xml.Serialization
             ImportedMappings.Add(dataType, enumMapping);
             Scope.AddTypeMapping(enumMapping);
             return enumMapping;
+        }
+
+        private static bool TryGetDataContractEnumValue(XmlSchemaAnnotation annotation, out long value)
+        {
+            value = default;
+
+            if (annotation?.Items == null)
+            {
+                return false;
+            }
+
+            foreach (XmlSchemaObject annotationItem in annotation.Items)
+            {
+                XmlSchemaAppInfo appInfo = annotationItem as XmlSchemaAppInfo;
+                if (appInfo?.Markup == null)
+                {
+                    continue;
+                }
+
+                foreach (XmlNode node in appInfo.Markup)
+                {
+                    XmlElement element = node as XmlElement;
+                    if (element != null
+                        && element.LocalName == "EnumerationValue"
+                        && element.NamespaceURI == "http://schemas.microsoft.com/2003/10/Serialization/"
+                        && long.TryParse(element.InnerText, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private PrimitiveMapping ImportPrimitiveDataType(XmlSchemaSimpleType dataType)

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/XmlSchemaImporter.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/XmlSchemaImporter.cs
@@ -1855,6 +1855,7 @@ namespace Microsoft.Xml.Serialization
             if (content is XmlSchemaSimpleTypeRestriction)
             {
                 XmlSchemaSimpleTypeRestriction restriction = (XmlSchemaSimpleTypeRestriction)content;
+                int enumIndex = 0;
                 for (int i = 0; i < restriction.Facets.Count; i++)
                 {
                     object facet = restriction.Facets[i];
@@ -1869,8 +1870,9 @@ namespace Microsoft.Xml.Serialization
                     string constantName = CodeIdentifier.MakeValid(enumeration.Value);
                     constant.Name = constants.AddUnique(constantName, constant);
                     constant.XmlName = enumeration.Value;
-                    long defaultValue = isList ? (1L << i) : i;
+                    long defaultValue = isList ? (1L << enumIndex) : enumIndex;
                     constant.Value = TryGetDataContractEnumValue(enumeration.Annotation, out long enumValue) ? enumValue : defaultValue;
+                    enumIndex++;
                 }
             }
             enumMapping.Constants = (ConstantMapping[])constants.ToArray(typeof(ConstantMapping));

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/XmlSchemaImporter.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.Xml/Xml/Serialization/XmlSchemaImporter.cs
@@ -1869,7 +1869,8 @@ namespace Microsoft.Xml.Serialization
                     string constantName = CodeIdentifier.MakeValid(enumeration.Value);
                     constant.Name = constants.AddUnique(constantName, constant);
                     constant.XmlName = enumeration.Value;
-                    constant.Value = i;
+                    long defaultValue = isList ? (1L << i) : i;
+                    constant.Value = TryGetDataContractEnumValue(enumeration.Annotation, out long enumValue) ? enumValue : defaultValue;
                 }
             }
             enumMapping.Constants = (ConstantMapping[])constants.ToArray(typeof(ConstantMapping));
@@ -1883,6 +1884,39 @@ namespace Microsoft.Xml.Serialization
             ImportedMappings.Add(dataType, enumMapping);
             Scope.AddTypeMapping(enumMapping);
             return enumMapping;
+        }
+
+        private static bool TryGetDataContractEnumValue(XmlSchemaAnnotation annotation, out long value)
+        {
+            value = default;
+
+            if (annotation?.Items == null)
+            {
+                return false;
+            }
+
+            foreach (XmlSchemaObject annotationItem in annotation.Items)
+            {
+                XmlSchemaAppInfo appInfo = annotationItem as XmlSchemaAppInfo;
+                if (appInfo?.Markup == null)
+                {
+                    continue;
+                }
+
+                foreach (XmlNode node in appInfo.Markup)
+                {
+                    XmlElement element = node as XmlElement;
+                    if (element != null
+                        && element.LocalName == "EnumerationValue"
+                        && element.NamespaceURI == "http://schemas.microsoft.com/2003/10/Serialization/"
+                        && long.TryParse(element.InnerText, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         internal class ElementComparer : IComparer

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
@@ -1140,145 +1140,145 @@ namespace XmlSerializer_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
@@ -1505,145 +1505,145 @@ namespace wrapped_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
@@ -618,8 +618,8 @@ namespace Saml2IssuedToken_mex_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(Saml2IssuedToken_mex_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.TestFaultsResponse> TestFaultsAsync(Saml2IssuedToken_mex_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace Saml2IssuedToken_mex_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
@@ -618,8 +618,8 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(BasicHttpsTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
@@ -618,8 +618,8 @@ namespace BasicHttp_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttp_NS.TestFaultsResponse> TestFaultsAsync(BasicHttp_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace BasicHttp_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
@@ -618,8 +618,8 @@ namespace BasicHttps_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(BasicHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<BasicHttps_NS.TestFaultsResponse> TestFaultsAsync(BasicHttps_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace BasicHttps_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
@@ -618,8 +618,8 @@ namespace NetHttp_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttp_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttp_NS.TestFaultsResponse> TestFaultsAsync(NetHttp_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace NetHttp_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
@@ -618,8 +618,8 @@ namespace NetHttpWebSockets_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpWebSockets_NS.TestFaultsResponse> TestFaultsAsync(NetHttpWebSockets_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace NetHttpWebSockets_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
@@ -618,8 +618,8 @@ namespace NetHttps_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttps_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttps_NS.TestFaultsResponse> TestFaultsAsync(NetHttps_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace NetHttps_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
@@ -618,8 +618,8 @@ namespace NetHttpsWebSockets_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NetHttpsWebSockets_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<NetHttpsWebSockets_NS.TestFaultsResponse> TestFaultsAsync(NetHttpsWebSockets_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace NetHttpsWebSockets_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
@@ -618,8 +618,8 @@ namespace TcpTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(TcpTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(TcpTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace TcpTransSecMessCredsUserName_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
@@ -618,8 +618,8 @@ namespace HttpsTransSecMessCredsUserName_NS
         System.Threading.Tasks.Task TestFaultIntAsync(int faultCode);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IWcfService/TestFaults", ReplyAction="http://tempuri.org/IWcfService/TestFaultsResponse")]
-        [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name="FaultDetail", Namespace="http://www.contoso.com/wcfnamespace")]
+        [System.ServiceModel.FaultContractAttribute(typeof(HttpsTransSecMessCredsUserName_NS.FaultDetail), Action="http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name="FaultDetail2", Namespace="http://www.contoso.com/wcfnamespace")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
         System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(HttpsTransSecMessCredsUserName_NS.TestFaultsRequest request);
         
@@ -1347,145 +1347,145 @@ namespace HttpsTransSecMessCredsUserName_NS
     {
         
         /// <remarks/>
-        Continue,
+        Continue = 100,
         
         /// <remarks/>
-        SwitchingProtocols,
+        SwitchingProtocols = 101,
         
         /// <remarks/>
-        OK,
+        OK = 200,
         
         /// <remarks/>
-        Created,
+        Created = 201,
         
         /// <remarks/>
-        Accepted,
+        Accepted = 202,
         
         /// <remarks/>
-        NonAuthoritativeInformation,
+        NonAuthoritativeInformation = 203,
         
         /// <remarks/>
-        NoContent,
+        NoContent = 204,
         
         /// <remarks/>
-        ResetContent,
+        ResetContent = 205,
         
         /// <remarks/>
-        PartialContent,
+        PartialContent = 206,
         
         /// <remarks/>
-        MultipleChoices,
+        MultipleChoices = 300,
         
         /// <remarks/>
-        Ambiguous,
+        Ambiguous = 300,
         
         /// <remarks/>
-        MovedPermanently,
+        MovedPermanently = 301,
         
         /// <remarks/>
-        Moved,
+        Moved = 301,
         
         /// <remarks/>
-        Found,
+        Found = 302,
         
         /// <remarks/>
-        Redirect,
+        Redirect = 302,
         
         /// <remarks/>
-        SeeOther,
+        SeeOther = 303,
         
         /// <remarks/>
-        RedirectMethod,
+        RedirectMethod = 303,
         
         /// <remarks/>
-        NotModified,
+        NotModified = 304,
         
         /// <remarks/>
-        UseProxy,
+        UseProxy = 305,
         
         /// <remarks/>
-        Unused,
+        Unused = 306,
         
         /// <remarks/>
-        TemporaryRedirect,
+        TemporaryRedirect = 307,
         
         /// <remarks/>
-        RedirectKeepVerb,
+        RedirectKeepVerb = 307,
         
         /// <remarks/>
-        BadRequest,
+        BadRequest = 400,
         
         /// <remarks/>
-        Unauthorized,
+        Unauthorized = 401,
         
         /// <remarks/>
-        PaymentRequired,
+        PaymentRequired = 402,
         
         /// <remarks/>
-        Forbidden,
+        Forbidden = 403,
         
         /// <remarks/>
-        NotFound,
+        NotFound = 404,
         
         /// <remarks/>
-        MethodNotAllowed,
+        MethodNotAllowed = 405,
         
         /// <remarks/>
-        NotAcceptable,
+        NotAcceptable = 406,
         
         /// <remarks/>
-        ProxyAuthenticationRequired,
+        ProxyAuthenticationRequired = 407,
         
         /// <remarks/>
-        RequestTimeout,
+        RequestTimeout = 408,
         
         /// <remarks/>
-        Conflict,
+        Conflict = 409,
         
         /// <remarks/>
-        Gone,
+        Gone = 410,
         
         /// <remarks/>
-        LengthRequired,
+        LengthRequired = 411,
         
         /// <remarks/>
-        PreconditionFailed,
+        PreconditionFailed = 412,
         
         /// <remarks/>
-        RequestEntityTooLarge,
+        RequestEntityTooLarge = 413,
         
         /// <remarks/>
-        RequestUriTooLong,
+        RequestUriTooLong = 414,
         
         /// <remarks/>
-        UnsupportedMediaType,
+        UnsupportedMediaType = 415,
         
         /// <remarks/>
-        RequestedRangeNotSatisfiable,
+        RequestedRangeNotSatisfiable = 416,
         
         /// <remarks/>
-        ExpectationFailed,
+        ExpectationFailed = 417,
         
         /// <remarks/>
-        UpgradeRequired,
+        UpgradeRequired = 426,
         
         /// <remarks/>
-        InternalServerError,
+        InternalServerError = 500,
         
         /// <remarks/>
-        NotImplemented,
+        NotImplemented = 501,
         
         /// <remarks/>
-        BadGateway,
+        BadGateway = 502,
         
         /// <remarks/>
-        ServiceUnavailable,
+        ServiceUnavailable = 503,
         
         /// <remarks/>
-        GatewayTimeout,
+        GatewayTimeout = 504,
         
         /// <remarks/>
-        HttpVersionNotSupported,
+        HttpVersionNotSupported = 505,
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]


### PR DESCRIPTION
Fixes explicit enum value loss in dotnet-svcutil when XmlSerializer is used (values were previously replaced by default ordering).
* Updates enum import/codegen to preserve ser:EnumerationValue, emit ConstantMapping.Value, and keep existing fallback behavior when the annotation is not present.
* Updates existing test baselines to match corrected output.
* Context: surfaced from issue #4105 (DataSet scenario selecting XmlSerializer), but also repros without DataSet usage when XmlSerializer is used.