### PR TITLE
Upgrade to V4 arcade publishing

### DIFF
--- a/azure-pipelines-arcade-PR.yml
+++ b/azure-pipelines-arcade-PR.yml
@@ -23,8 +23,6 @@ pr:
 variables:  
   - name: _TeamName
     value: WcfCore
-  - name: _PublishUsingPipelines
-    value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: _RunAsPublic
@@ -58,7 +56,6 @@ stages:
       enableMicrobuild: true
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: $(_PublishUsingPipelines)
       enableTelemetry: true
       helixRepo: dotnet/wcf
       jobs:

--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -15,8 +15,6 @@ variables:
   value: WcfCore
 - name: TeamName
   value: WcfCore
-- name: _PublishUsingPipelines
-  value: true
 - name: _DotNetArtifactsCategory
   value: .NETCore
 - name: _RunAsPublic
@@ -65,13 +63,14 @@ extends:
         parameters:
           enableMicrobuild: true
           enablePublishBuildArtifacts: true
+          publishingVersion: 4
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: $(_PublishUsingPipelines)
           enableTelemetry: true
           enableSourceIndex: ${{ eq(variables['Build.SourceBranch'], 'refs/heads/main') }}
           helixRepo: dotnet/wcf
           jobs:
           - job: Windows
+            enablePublishing: true
             timeoutInMinutes: 90
             pool:
               ${{ if eq(variables._RunAsInternal, True) }}:
@@ -86,7 +85,7 @@ extends:
               - group: Publish-Build-Assets
               - group: DotNet-HelixApi-Access
               - _PublishBlobFeedUrl: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
-              - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed) /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines) /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory) /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+              - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed) /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory) /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
               - _serviceUri: wcfcoresrv53.westus3.cloudapp.azure.com/WcfTestService1
             - _xUnitWorkItemTimeout: '00:10:00'
             strategy:
@@ -115,7 +114,7 @@ extends:
         parameters:
           validateDependsOn:
           - Build
-          publishingInfraVersion: 3
+          publishingInfraVersion: 4
           enableSymbolValidation: false
           enableSourceLinkValidation: false
           SDLValidationParameters:

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,5 @@
 <Project>
-    <PropertyGroup>
-       <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
-    </PropertyGroup>
- </Project>
+  <PropertyGroup>
+    <PublishingVersion>4</PublishingVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- switch Arcade publishing to V4
- remove obsolete V3 pipeline publishing plumbing
- update post-build validation to use V4 artifacts

Part of dotnet/arcade#16697