### PR TITLE
Separate xUnit compatibility fix from Arcade update PR

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -63,6 +63,14 @@
   <ItemGroup Condition="Exists('README.md')" >
     <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
+
+  <Target Name="RemoveXunitV3AssertAotReference" BeforeTargets="CoreCompile" Condition="'$(IsTestProject)' == 'true'">
+    <ItemGroup>
+      <ReferencePath Remove="@(ReferencePath)" Condition="$([System.String]::Copy('%(ReferencePath.Identity)').EndsWith('xunit.v3.assert.aot.dll', System.StringComparison.OrdinalIgnoreCase))" />
+      <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)" Condition="$([System.String]::Copy('%(ReferencePathWithRefAssemblies.Identity)').EndsWith('xunit.v3.assert.aot.dll', System.StringComparison.OrdinalIgnoreCase))" />
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::Copy('%(ReferenceCopyLocalPaths.Identity)').EndsWith('xunit.v3.assert.aot.dll', System.StringComparison.OrdinalIgnoreCase))" />
+    </ItemGroup>
+  </Target>
   
   <Import Project="eng\RuntimePackages.targets" Condition="'$(StrongNameKeyId)' == 'Microsoft'" />
 </Project>

--- a/src/dotnet-svcutil/lib/tests/src/dotnet-svcutil-lib.Tests.csproj
+++ b/src/dotnet-svcutil/lib/tests/src/dotnet-svcutil-lib.Tests.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
+﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
   <!-- $(RepositoryRoot)Directory.Build.props automatically imported by Microsoft.Common.props -->
   <PropertyGroup>
     <AssemblyVersionFile>$(IntermediateOutputPath)\$(TargetFramework)\$(MSBuildProjectName).$(TargetFramework).version.cs</AssemblyVersionFile>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(UnitTestTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn)NETSDK1023</NoWarn>
     <CLSCompliant>false</CLSCompliant>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
This PR extracts the xUnit package compatibility fix from the Arcade dependency update PR (#5936).

The initial CI failure reported from dotnet-svcutil-lib.Tests.csproj:
`NU1202: xunit.v3.assert.aot 3.2.2 is not compatible with net8.0`

Local reproduction showed additional xUnit conflicts affecting multiple test projects, this change fixes those issues separately to unblock the Arcade update PR. 

Example:
`error CS0433: The type 'Assert' exists in both 'xunit.assert, Version=2.9.3.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c' and 'xunit.v3.assert.aot, Version=3.2.2.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c'`