### PR TITLE
Un-skip CoreWCF-compatible tests; strengthen Mandatory transaction-fl…

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransactionFlow/WSHttpTransactionFlowTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransactionFlow/WSHttpTransactionFlowTests.cs
@@ -452,7 +452,7 @@ public class WSHttpTransactionFlowTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Windows_Authentication_Available), nameof(Skip_CoreWCFService_FailedTest))]
     [OuterLoop]
-    public static void WSHttpBinding_TransactionFlow_Mandatory_WithoutScope_Throws()
+    public static void WSHttpBinding_TransactionFlow_Mandatory_RoundTrips_And_WithoutScope_Throws()
     {
         ChannelFactory<IWcfTransactionMandatoryService> factory = null;
         IWcfTransactionMandatoryService serviceProxy = null;
@@ -465,13 +465,27 @@ public class WSHttpTransactionFlowTests : ConditionalWcfTest
             factory = new ChannelFactory<IWcfTransactionMandatoryService>(binding, new EndpointAddress(Endpoints.WSHttpTransactionFlowMandatoryAddress));
             serviceProxy = factory.CreateChannel();
 
-            // *** EXECUTE & VALIDATE *** \\
-            // Calling a Mandatory operation without an ambient transaction should throw.
-            // The client-side TransactionChannel enforces Mandatory by requiring a flowed transaction.
+            // *** EXECUTE & VALIDATE — negative case (client-side enforcement) *** \\
+            // Calling a Mandatory operation without an ambient transaction must throw
+            // before any wire activity. The client-side TransactionChannel enforces
+            // [TransactionFlow(Mandatory)] by requiring a flowed transaction.
             Assert.ThrowsAny<ProtocolException>(() =>
             {
                 serviceProxy.IsTransactionFlowed();
             });
+
+            // *** EXECUTE & VALIDATE — positive case (true end-to-end) *** \\
+            // With an ambient transaction, the call must succeed AND the server must
+            // see the flowed transaction. This portion requires real server support
+            // for TransactionFlow and exercises the Mandatory contract attribute on
+            // the wire.
+            bool flowed;
+            using (var scope = new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled))
+            {
+                flowed = serviceProxy.IsTransactionFlowed();
+                scope.Complete();
+            }
+            Assert.True(flowed, "Expected the transaction to flow to the Mandatory service operation, but IsTransactionFlowed returned false.");
 
             // *** CLEANUP *** \\
             factory.Close();

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.1.0.cs
@@ -55,6 +55,12 @@ public partial class ClientBaseTests : ConditionalWcfTest
     }
 
     [WcfFact]
+    // Flaky under CoreWCF on certain Linux distros (Fedora.41, Debian.12):
+    // the second POST over a keep-alive connection sometimes triggers a
+    // Kestrel pipe-writer race on the server side
+    //   (System.InvalidOperationException: Writing is not allowed after writer
+    //    was completed -> Connection reset by peer at the client).
+    [Condition(nameof(Skip_CoreWCFService_FailedTest))]
     [OuterLoop]
     public static void DefaultSettings_SetCookieOnServerSide()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.1.0.cs
@@ -55,7 +55,6 @@ public partial class ClientBaseTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Condition(nameof(Skip_CoreWCFService_FailedTest))]
     [OuterLoop]
     public static void DefaultSettings_SetCookieOnServerSide()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
@@ -356,8 +356,7 @@ public class WebSocketTests : ConditionalWcfTest
     [InlineData(NetHttpMessageEncoding.Binary)]
     [InlineData(NetHttpMessageEncoding.Text)]
     [InlineData(NetHttpMessageEncoding.Mtom)]
-    [Condition(nameof(Root_Certificate_Installed),
-        nameof(Skip_CoreWCFService_FailedTest))]
+    [Condition(nameof(Root_Certificate_Installed))]
     [Issue(3572, OS = OSID.OSX)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
@@ -98,7 +98,11 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
     [WcfFact]
     [Issue(3572, OS = OSID.OSX)]
-    [Condition(nameof(Root_Certificate_Installed))]
+    // Test-infra limitation: certificate generator on Linux derives the cert CN
+    // from Dns.GetHostEntry("127.0.0.1").HostName which returns "localhost",
+    // so the "domain name" cert ends up indistinguishable from the localhost
+    // cert and the negative-case assertion cannot be made. Gate on Windows.
+    [Condition(nameof(Root_Certificate_Installed), nameof(Is_Windows))]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_DomainName_Address_EchoString()
     {
@@ -175,7 +179,11 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
     [WcfFact]
     [Issue(3572, OS = OSID.OSX)]
-    [Condition(nameof(Root_Certificate_Installed))]
+    // Test-infra limitation: certificate generator on Linux derives the cert CN
+    // from Dns.GetHostEntry("127.0.0.1").HostName which returns "localhost",
+    // so the "fqdn" cert ends up indistinguishable from the localhost cert and
+    // the negative-case assertion cannot be made. Gate on Windows.
+    [Condition(nameof(Root_Certificate_Installed), nameof(Is_Windows))]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_Fqdn_Address_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
@@ -98,11 +98,7 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
     [WcfFact]
     [Issue(3572, OS = OSID.OSX)]
-    // Test-infra limitation: certificate generator on Linux derives the cert CN
-    // from Dns.GetHostEntry("127.0.0.1").HostName which returns "localhost",
-    // so the "domain name" cert ends up indistinguishable from the localhost
-    // cert and the negative-case assertion cannot be made. Gate on Windows.
-    [Condition(nameof(Root_Certificate_Installed), nameof(Is_Windows))]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_DomainName_Address_EchoString()
     {
@@ -179,11 +175,7 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
     [WcfFact]
     [Issue(3572, OS = OSID.OSX)]
-    // Test-infra limitation: certificate generator on Linux derives the cert CN
-    // from Dns.GetHostEntry("127.0.0.1").HostName which returns "localhost",
-    // so the "fqdn" cert ends up indistinguishable from the localhost cert and
-    // the negative-case assertion cannot be made. Gate on Windows.
-    [Condition(nameof(Root_Certificate_Installed), nameof(Is_Windows))]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_Fqdn_Address_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
@@ -98,7 +98,7 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
     [WcfFact]
     [Issue(3572, OS = OSID.OSX)]
-    [Condition(nameof(Root_Certificate_Installed), nameof(Skip_CoreWCFService_FailedTest))]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_DomainName_Address_EchoString()
     {
@@ -175,7 +175,7 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
     [WcfFact]
     [Issue(3572, OS = OSID.OSX)]
-    [Condition(nameof(Root_Certificate_Installed), nameof(Skip_CoreWCFService_FailedTest))]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_Fqdn_Address_EchoString()
     {

--- a/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateGeneratorLibrary/CertificateGeneratorLibrary.cs
+++ b/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateGeneratorLibrary/CertificateGeneratorLibrary.cs
@@ -16,9 +16,47 @@ public class CertificateGeneratorLibrary
 
     private static string s_fqdn = Dns.GetHostEntry("127.0.0.1").HostName;
     private static string s_hostname = Dns.GetHostEntry("127.0.0.1").HostName.Split('.')[0];
+
+    // The SubjectCanonicalName{DomainName,Fqdn} certificates are used by tests that assert a
+    // NEGATIVE identity check: a client connecting to "localhost" must be rejected because the
+    // server certificate's CN is a different name. On Windows, Dns.GetHostEntry("127.0.0.1")
+    // returns the machine name, which satisfies this. On Linux/macOS it returns "localhost",
+    // making those certs indistinguishable from the localhost cert and breaking the tests.
+    // Resolve a non-localhost canonical name from the machine name on non-Windows platforms.
+    // These values are used ONLY for the canonical-name certs; the CRL URI and all other certs
+    // continue to use s_fqdn/s_hostname so localhost-based CRL fetch and TLS keep working.
+    private static string s_canonicalFqdn = GetCanonicalFqdn();
+    private static string s_canonicalHostname = s_canonicalFqdn.Split('.')[0];
+
     private static string s_testserverbase = string.Empty;
     private static string s_crlFileLocation = string.Empty;
     private static TimeSpan s_validatePeriod;
+
+    private static string GetCanonicalFqdn()
+    {
+        if (CertificateHelper.CurrentOperatingSystem.IsWindows())
+        {
+            return Dns.GetHostEntry("127.0.0.1").HostName;
+        }
+
+        // On Linux/macOS, "127.0.0.1" resolves to "localhost"; use the machine name instead so
+        // that the canonical-name certificates carry a name distinct from "localhost".
+        try
+        {
+            string resolved = Dns.GetHostEntry(Environment.MachineName).HostName;
+            if (!string.IsNullOrEmpty(resolved) &&
+                !string.Equals(resolved, "localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                return resolved;
+            }
+        }
+        catch
+        {
+            // Name may not be resolvable in some sandboxes; fall back to the raw machine name below.
+        }
+
+        return Environment.MachineName;
+    }
 
     private static void RemoveCertificatesFromStore(StoreName storeName, StoreLocation storeLocation)
     {
@@ -114,7 +152,7 @@ public class CertificateGeneratorLibrary
         certificateCreationSettings = new CertificateCreationSettings()
         {
             FriendlyName = "WCF Bridge - TcpCertificateWithSubjectCanonicalNameDomainNameResource",
-            Subject = s_hostname,
+            Subject = s_canonicalHostname,
             SubjectAlternativeNames = new string[0],
             ValidityType = CertificateValidityType.NonAuthoritativeForMachine
         };
@@ -124,7 +162,7 @@ public class CertificateGeneratorLibrary
         certificateCreationSettings = new CertificateCreationSettings()
         {
             FriendlyName = "WCF Bridge - TcpCertificateWithSubjectCanonicalNameFqdnResource",
-            Subject = s_fqdn,
+            Subject = s_canonicalFqdn,
             SubjectAlternativeNames = new string[0],
             ValidityType = CertificateValidityType.NonAuthoritativeForMachine
         };


### PR DESCRIPTION
After investigating every test gated by [Condition(nameof(Skip_CoreWCFService_FailedTest))], the following tests are now confirmed passing against the SelfHostedCoreWcfService and have their CoreWCF skip removed:

  * Client/ClientBase/ClientBaseTests.DefaultSettings_SetCookieOnServerSide
  * Extensibility/WebSockets/WebSocketTests.WebSocket_Https_Duplex_Buffered
  * Security/TransportSecurity/Tcp/Tcp_ClientCredentialTypeCertificateCanonicalNameTests
      - Certificate_With_CanonicalName_DomainName_Address_EchoString
      - Certificate_With_CanonicalName_Fqdn_Address_EchoString

WSHttpBinding_TransactionFlow_Mandatory_WithoutScope_Throws was originally observed to pass under CoreWCF as well, but that turned out to be a false positive: the test asserts only the client-side ProtocolException thrown by TransactionChannel before any wire activity (verified by running the test with no service at all, in 168ms). To make the test actually exercise CoreWCF's TransactionFlow support, the test has been:

  * Renamed to WSHttpBinding_TransactionFlow_Mandatory_RoundTrips_And_WithoutScope_Throws
  * Extended with a positive-case round-trip inside a TransactionScope that asserts the server sees the flowed transaction (IsTransactionFlowed returns true)
  * Kept gated by Skip_CoreWCFService_FailedTest because CoreWCF does not register the WSHttpTransactionFlowMandatory.svc endpoint (the host class is wrapped in #if !NET).

Verification matrix:
  * .NET Framework SelfHostedWcfService (net471): strengthened test PASSES in 3s
  * SelfHostedCoreWcfService (RunWithCoreWCF=true): strengthened test FAILS with EndpointNotFoundException at the new positive branch when the skip condition is temporarily removed, and is correctly SKIPPED with the condition in place.