### PR TITLE
dotnet-svcutil: support WCF 10.* and make TFM->package mapping forward-compatible

### DIFF
--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     }
                     else
                     {
-                        msbuildProj._targetFramework = string.Concat("net", TargetFrameworkHelper.s_currentSupportedVersions.First());
+                        msbuildProj._targetFramework = string.Concat("net", TargetFrameworkHelper.MinSupportedDotNetVersion);
                     }
 
                     msbuildProj._targetFrameworks.Add(msbuildProj._targetFramework);

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 {
     internal class TargetFrameworkHelper
     {
-        internal static readonly List<string> s_currentSupportedVersions = new List<string>() { "8.0", "9.0", "10.0" };
+        internal const string MinSupportedDotNetVersion = "8.0";
         public static Version MinSupportedNetFxVersionForDotNet { get; } = new Version("4.5");
         public static Version MinSupportedNetStandardVersion { get; } = new Version("1.3");
         public static Version MinSupportedNetCoreAppVersion { get; } = new Version("1.0");
@@ -27,10 +27,15 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 ProjectDependency.FromPackage("System.ServiceModel.Security", "4.10.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.Federation", "4.10.*")
             } },
-            {"Current", new List<ProjectDependency> {
+            {"Net8", new List<ProjectDependency> {
                 ProjectDependency.FromPackage("System.ServiceModel.Http", "8.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "8.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.Primitives", "8.*")
+            } },
+            {"Net10", new List<ProjectDependency> {
+                ProjectDependency.FromPackage("System.ServiceModel.Http", "10.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "10.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "10.*")
             } }
         };
 
@@ -62,20 +67,27 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 return FullFrameworkReferences;
             }
 
-            // Determine the lowest .NET Core version in the target frameworks
+            // Determine the lowest .NET (Core) version in the target frameworks (netstandard is excluded by GetLowestNetCoreVersion).
+            // Selection uses a >= threshold (not a closed list) so that future .NET versions (net11.0, net12.0, ...) automatically
+            // pick the highest currently-supported bucket instead of silently dropping to the Legacy 4.10.* set.
             Version netCoreVersion = GetLowestNetCoreVersion(targetFrameworks);
 
-            // Return the appropriate WCF reference based on the target framework version
-            // Behavior table based on framework combinations:
-            // netstandard2.0       :  add WCF reference 4.10.*
-            // netstandard2.0;net8.0:  add WCF reference 8.*
-            // netstandard2.0;net6.0:  add WCF reference 4.10.*
-            // net6.0;net8.0        :  add WCF reference 4.10.*
-            if (netCoreVersion != null && s_currentSupportedVersions.Contains(netCoreVersion.ToString()))
+            // Mapping (lowest DNX TFM wins):
+            //   >= net10.0  -> Net10  (10.*)
+            //   >= net8.0   -> Net8   (8.*)
+            //   otherwise   -> Legacy (4.10.*)  -- includes netstandard-only, net6.0/7.0, and mixed older+newer DNX combos.
+            if (netCoreVersion != null)
             {
-                return NetCoreVersionReferenceTable["Current"];
+                if (netCoreVersion >= new Version(10, 0))
+                {
+                    return NetCoreVersionReferenceTable["Net10"];
+                }
+                if (netCoreVersion >= new Version(8, 0))
+                {
+                    return NetCoreVersionReferenceTable["Net8"];
+                }
             }
-            // Otherwise, return the legacy WCF reference
+
             return NetCoreVersionReferenceTable["Legacy"];
         }
 
@@ -152,7 +164,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 // Return true if .NET version is less than the lowest supported Version
                 return frameworkInfo.IsDnx
                     && !frameworkInfo.Name.Equals(FrameworkInfo.Netstandard, StringComparison.OrdinalIgnoreCase)
-                    && frameworkInfo.Version < new Version(s_currentSupportedVersions.First());
+                    && frameworkInfo.Version < new Version(MinSupportedDotNetVersion);
             }
 
             // Return false if parsing fails or no conditions matched


### PR DESCRIPTION
## Problem

`TargetFrameworkHelper.GetWcfProjectReferences` (used by `dotnet-svcutil` to add `<PackageReference>` entries to a user project after generating WCF proxy code) had two issues:

1. **No WCF 10.\* support.** The "Current" bucket pinned WCF packages to `8.*` for every TFM in `s_currentSupportedVersions = { "8.0", "9.0", "10.0" }`, so a project targeting `net10.0` still got the `8.*` packages.

2. **Forward-compatibility regression waiting to happen.** Selection used a closed-list `Contains(...)` check. As soon as the SDK bumps to `net11.0+`, the lookup misses → the tool silently falls through to the **Legacy `4.10.*` bucket** (5 packages instead of 3), which would mass-break test baselines (`FixupUtil.cs` normalizes package versions but not the number/set of packages).

## Changes

`src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs`
- Add a `Net10` bucket pinned to **WCF `10.*`** (`System.ServiceModel.Http`, `NetTcp`, `Primitives`).
- Rename the existing `Current` bucket → `Net8` for clarity (same 3 packages at `8.*`).
- Replace the closed-list membership check with a `>=` threshold so future .NET versions automatically pick the highest available bucket:

  | Project's lowest DNX TFM | Bucket | Packages |
  |---|---|---|
  | `>= net10.0` (incl. future net11+) | **Net10** | Http / NetTcp / Primitives @ `10.*` |
  | `net8.0` / `net9.0` | **Net8** | Http / NetTcp / Primitives @ `8.*` |
  | anything older / netstandard-only / mixed with older DNX | **Legacy** | Duplex / Http / NetTcp / Security / Federation @ `4.10.*` |
  | no DNX TFM (e.g. `net462` only) | unchanged | `System.ServiceModel` assembly reference |

- Remove the now-unused `s_currentSupportedVersions` list. Both remaining callers (`IsEndofLifeFramework`, `MSBuildProj.ParseAsync` default-TFM fallback) only used `.First()`, so it collapses to a single `internal const string MinSupportedDotNetVersion = "8.0"`.

`src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs`
- Update the default-TFM fallback to use `MinSupportedDotNetVersion`.

## Behavior preservation

- `net8.0`, `net9.0`, `net10.0` projects all still emit the same 3-package set, so existing baselines remain valid (`FixupUtil.cs:51` normalizes versions per-line).
- `netstandard2.0`-only, `net6.0`, `net48`, `net462;netstandard2.0` continue to hit the Legacy bucket as before.
- `net462`-only continues to receive the full-framework `System.ServiceModel` assembly reference (early return path, untouched).
- `IsEndofLifeFramework` semantics unchanged (boundary is still `8.0`).

## Forward-compat win

When arcade bumps the SDK to `net11.0+`, the new logic picks the `Net10` bucket (3 packages) instead of dropping into the Legacy 5-package set — no baseline churn required at that point.
