### PR TITLE
Fix Sync_PRService_Windows never invoking sync-pr.cmd

### DIFF
--- a/eng/UpdatePRService.yml
+++ b/eng/UpdatePRService.yml
@@ -96,8 +96,11 @@ steps:
       Write-Host "Variable Operation is set to: $env:operation"
       Write-Host "Variable wcfPRServiceUri is set to: $env:WCFPRSERVICEURI"
       Write-Host "Variable branchNameorPrId is set to: $env:branchNameorPrId"
-      invoke-command -Scriptblock { & "$env:Build_SourcesDirectory\src\System.Private.ServiceModel\tools\scripts\sync-pr.cmd "$env:WCFPRSERVICEID $env:operation $env:WCFPRSERVICEURI $env:branchNameorPrId"" }
-      $LASTEXITCODE
+      & "$env:Build_SourcesDirectory\src\System.Private.ServiceModel\tools\scripts\sync-pr.cmd" $env:WCFPRSERVICEID $env:operation $env:WCFPRSERVICEURI $env:branchNameorPrId
+      Write-Host "sync-pr.cmd exit code: $LASTEXITCODE"
+      if ($LASTEXITCODE -ne 0) {
+        Write-Host "##vso[task.logissue type=warning]sync-pr.cmd failed with exit code $LASTEXITCODE - the test service was NOT synced to this PR."
+      }
 
     displayName: Sync_PRService_Windows
     env:


### PR DESCRIPTION
The Windows PR-service sync step never ran sync-pr.cmd, so the WCF test service was never synced to the PR on the Windows and macOS legs (macOS jobs orchestrate on Windows agents, so they take this same step).

The invocation was:

  & "$env:Build_SourcesDirectory\...\sync-pr.cmd "$env:WCFPRSERVICEID ...""

PowerShell parses this by juxtaposition, so the command name becomes "...\sync-pr.cmd " with a trailing space and the remaining text is folded in as arguments (the last one is not even expanded - it tokenizes as the literal CommandArgument "$env:branchNameorPrId"). The trailing space defeats PATHEXT matching, so PowerShell treats the target as a document rather than an application and ShellExecutes it. Under Windows PowerShell 5.1 - the shell the pipeline task uses - that is a silent no-op: no stdout, no error record, and $LASTEXITCODE is left untouched, so the step reports success while doing nothing.

This is observable in any build: sync-pr.cmd echoes a banner unconditionally before it validates its arguments, and that banner never appears in the Windows step log, while the Unix step log contains it along with "Making call to <sync url>".

The practical effect is that a PR which adds a new endpoint to IISHostedWcfService only gets that endpoint deployed on the slots synced by the Linux legs, and the scenario tests fail on the other legs against a stale service.

Invoke the script properly and surface a non-zero exit code as a pipeline warning so a future failure is not silent again.