### PR TITLE
Fix callback dispatch inspector correlation state

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.4.1.0.cs
@@ -4,7 +4,14 @@
 
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
 using System.Threading.Tasks;
 using Infrastructure.Common;
 using Xunit;
@@ -55,6 +62,98 @@ public static class TypedProxyDuplexTests
 
     [WcfFact]
     [OuterLoop]
+    public static void ServiceContract_TypedProxy_AsyncTask_CallbackDispatchRuntime_MessageInspector_CorrelationStatePreserved()
+    {
+        CallbackDispatchInspectorBehavior behavior = new CallbackDispatchInspectorBehavior(addParameterInspector: false);
+        Guid guid = Guid.NewGuid();
+
+        Guid returnedGuid = CallDuplexTaskReturnService(guid, behavior);
+
+        Assert.Equal(guid, returnedGuid);
+        Assert.True(behavior.MessageInspector.AfterReceiveRequestCalled);
+        Assert.True(behavior.MessageInspector.BeforeSendReplyCalled);
+        Assert.Same(behavior.MessageInspector.CorrelationState, behavior.MessageInspector.CorrelationStateSeen);
+    }
+
+    [WcfFact]
+    [OuterLoop]
+    public static void ServiceContract_TypedProxy_AsyncTask_ClientAndCallbackDispatchRuntime_MultipleMessageInspectors_CorrelationStatesAndOrderPreserved()
+    {
+        const int InspectorCount = 3;
+        MultipleMessageInspectorsBehavior behavior = new MultipleMessageInspectorsBehavior(InspectorCount);
+        Guid guid = Guid.NewGuid();
+
+        Guid returnedGuid = CallDuplexTaskReturnService(guid, behavior);
+
+        Assert.Equal(guid, returnedGuid);
+
+        int[] expectedOrder = new int[] { 0, 1, 2 };
+        Assert.Equal(expectedOrder, behavior.ClientBeforeSendRequestOrder);
+        Assert.Equal(expectedOrder, behavior.ClientAfterReceiveReplyOrder);
+        Assert.Equal(expectedOrder, behavior.CallbackAfterReceiveRequestOrder);
+        Assert.Equal(expectedOrder, behavior.CallbackBeforeSendReplyOrder);
+
+        object[] correlationStates = behavior.ClientMessageInspectors
+            .Select(inspector => inspector.CorrelationState)
+            .Concat(behavior.CallbackMessageInspectors.Select(inspector => inspector.CorrelationState))
+            .ToArray();
+        Assert.Equal(InspectorCount * 2, correlationStates.Distinct().Count());
+
+        foreach (OrderedClientMessageInspector inspector in behavior.ClientMessageInspectors)
+        {
+            Assert.Same(inspector.CorrelationState, inspector.CorrelationStateSeen);
+        }
+
+        foreach (OrderedCallbackDispatchMessageInspector inspector in behavior.CallbackMessageInspectors)
+        {
+            Assert.Same(inspector.CorrelationState, inspector.CorrelationStateSeen);
+        }
+    }
+
+    [WcfFact]
+    [OuterLoop]
+    public static void ServiceContract_TypedProxy_AsyncTask_CallbackDispatchRuntime_MultipleMessageInspectors_NullAndObjectCorrelationStatesPreserved()
+    {
+        object expectedCorrelationState = new object();
+        CallbackDispatchMessageInspectorsBehavior behavior = new CallbackDispatchMessageInspectorsBehavior(
+            new object[] { null, expectedCorrelationState });
+        Guid guid = Guid.NewGuid();
+
+        Guid returnedGuid = CallDuplexTaskReturnService(guid, behavior);
+
+        Assert.Equal(guid, returnedGuid);
+
+        int[] expectedOrder = new int[] { 0, 1 };
+        Assert.Equal(expectedOrder, behavior.AfterReceiveRequestOrder);
+        Assert.Equal(expectedOrder, behavior.BeforeSendReplyOrder);
+
+        Assert.Null(behavior.MessageInspectors[0].CorrelationStateReturned);
+        Assert.Null(behavior.MessageInspectors[0].CorrelationStateSeen);
+        Assert.Same(expectedCorrelationState, behavior.MessageInspectors[1].CorrelationStateReturned);
+        Assert.Same(expectedCorrelationState, behavior.MessageInspectors[1].CorrelationStateSeen);
+    }
+
+    [WcfFact]
+    [OuterLoop]
+    public static void ServiceContract_TypedProxy_AsyncTask_CallbackDispatchRuntime_MessageAndParameterInspector_CorrelationStatesPreserved()
+    {
+        CallbackDispatchInspectorBehavior behavior = new CallbackDispatchInspectorBehavior(addParameterInspector: true);
+        Guid guid = Guid.NewGuid();
+
+        Guid returnedGuid = CallDuplexTaskReturnService(guid, behavior);
+
+        Assert.Equal(guid, returnedGuid);
+        Assert.True(behavior.MessageInspector.AfterReceiveRequestCalled);
+        Assert.True(behavior.MessageInspector.BeforeSendReplyCalled);
+        Assert.Same(behavior.MessageInspector.CorrelationState, behavior.MessageInspector.CorrelationStateSeen);
+        Assert.True(behavior.ParameterInspector.BeforeCallCalled);
+        Assert.True(behavior.ParameterInspector.AfterCallCalled);
+        Assert.Same(behavior.ParameterInspector.CorrelationState, behavior.ParameterInspector.CorrelationStateSeen);
+        Assert.NotSame(behavior.MessageInspector.CorrelationState, behavior.ParameterInspector.CorrelationState);
+    }
+
+    [WcfFact]
+    [OuterLoop]
     public static void DuplexChanelFactory_Ctor_Type_Overload_E2E()
     {
         DuplexChannelFactory<IWcfDuplexTaskReturnService> factory = null;
@@ -85,6 +184,317 @@ public static class TypedProxyDuplexTests
             {
                 factory.Abort();
             }
+        }
+    }
+
+    private static Guid CallDuplexTaskReturnService(Guid guid, IEndpointBehavior behavior)
+    {
+        DuplexChannelFactory<IWcfDuplexTaskReturnService> factory = null;
+
+        NetTcpBinding binding = new NetTcpBinding();
+        binding.Security.Mode = SecurityMode.None;
+
+        DuplexTaskReturnServiceCallback callbackService = new DuplexTaskReturnServiceCallback();
+        InstanceContext context = new InstanceContext(callbackService);
+
+        try
+        {
+            factory = new DuplexChannelFactory<IWcfDuplexTaskReturnService>(context, binding, new EndpointAddress(Endpoints.Tcp_NoSecurity_TaskReturn_Address));
+            factory.Endpoint.EndpointBehaviors.Add(behavior);
+            IWcfDuplexTaskReturnService serviceProxy = factory.CreateChannel();
+
+            Guid returnedGuid = serviceProxy.Ping(guid).GetAwaiter().GetResult();
+
+            factory.Close();
+            return returnedGuid;
+        }
+        finally
+        {
+            if (factory != null && factory.State != CommunicationState.Closed)
+            {
+                factory.Abort();
+            }
+        }
+    }
+
+    private sealed class CallbackDispatchMessageInspectorsBehavior : IEndpointBehavior
+    {
+        public CallbackDispatchMessageInspectorsBehavior(object[] correlationStates)
+        {
+            MessageInspectors = new OrderedCallbackDispatchMessageInspector[correlationStates.Length];
+
+            for (int i = 0; i < correlationStates.Length; i++)
+            {
+                MessageInspectors[i] = new OrderedCallbackDispatchMessageInspector(
+                    i,
+                    AfterReceiveRequestOrder,
+                    BeforeSendReplyOrder,
+                    correlationStates[i]);
+            }
+        }
+
+        public OrderedCallbackDispatchMessageInspector[] MessageInspectors { get; }
+
+        public List<int> AfterReceiveRequestOrder { get; } = new List<int>();
+
+        public List<int> BeforeSendReplyOrder { get; } = new List<int>();
+
+        public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+        {
+        }
+
+        public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+        {
+            for (int i = 0; i < MessageInspectors.Length; i++)
+            {
+                clientRuntime.CallbackDispatchRuntime.MessageInspectors.Add(MessageInspectors[i]);
+            }
+        }
+
+        public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+        {
+        }
+
+        public void Validate(ServiceEndpoint endpoint)
+        {
+        }
+    }
+
+    private sealed class MultipleMessageInspectorsBehavior : IEndpointBehavior
+    {
+        public MultipleMessageInspectorsBehavior(int inspectorCount)
+        {
+            ClientMessageInspectors = new OrderedClientMessageInspector[inspectorCount];
+            CallbackMessageInspectors = new OrderedCallbackDispatchMessageInspector[inspectorCount];
+
+            for (int i = 0; i < inspectorCount; i++)
+            {
+                ClientMessageInspectors[i] = new OrderedClientMessageInspector(
+                    i,
+                    ClientBeforeSendRequestOrder,
+                    ClientAfterReceiveReplyOrder);
+                CallbackMessageInspectors[i] = new OrderedCallbackDispatchMessageInspector(
+                    i,
+                    CallbackAfterReceiveRequestOrder,
+                    CallbackBeforeSendReplyOrder);
+            }
+        }
+
+        public OrderedClientMessageInspector[] ClientMessageInspectors { get; }
+
+        public OrderedCallbackDispatchMessageInspector[] CallbackMessageInspectors { get; }
+
+        public List<int> ClientBeforeSendRequestOrder { get; } = new List<int>();
+
+        public List<int> ClientAfterReceiveReplyOrder { get; } = new List<int>();
+
+        public List<int> CallbackAfterReceiveRequestOrder { get; } = new List<int>();
+
+        public List<int> CallbackBeforeSendReplyOrder { get; } = new List<int>();
+
+        public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+        {
+        }
+
+        public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+        {
+            for (int i = 0; i < ClientMessageInspectors.Length; i++)
+            {
+                clientRuntime.ClientMessageInspectors.Add(ClientMessageInspectors[i]);
+                clientRuntime.CallbackDispatchRuntime.MessageInspectors.Add(CallbackMessageInspectors[i]);
+            }
+        }
+
+        public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+        {
+        }
+
+        public void Validate(ServiceEndpoint endpoint)
+        {
+        }
+    }
+
+    private sealed class OrderedClientMessageInspector : IClientMessageInspector
+    {
+        private readonly int _index;
+        private readonly List<int> _beforeSendRequestOrder;
+        private readonly List<int> _afterReceiveReplyOrder;
+
+        public OrderedClientMessageInspector(int index, List<int> beforeSendRequestOrder, List<int> afterReceiveReplyOrder)
+        {
+            _index = index;
+            _beforeSendRequestOrder = beforeSendRequestOrder;
+            _afterReceiveReplyOrder = afterReceiveReplyOrder;
+        }
+
+        public object CorrelationState { get; } = new object();
+
+        public object CorrelationStateSeen { get; private set; }
+
+        public object BeforeSendRequest(ref Message request, IClientChannel channel)
+        {
+            _beforeSendRequestOrder.Add(_index);
+            return CorrelationState;
+        }
+
+        public void AfterReceiveReply(ref Message reply, object correlationState)
+        {
+            _afterReceiveReplyOrder.Add(_index);
+            CorrelationStateSeen = correlationState;
+        }
+    }
+
+    private sealed class OrderedCallbackDispatchMessageInspector : IDispatchMessageInspector
+    {
+        private readonly int _index;
+        private readonly List<int> _afterReceiveRequestOrder;
+        private readonly List<int> _beforeSendReplyOrder;
+
+        public OrderedCallbackDispatchMessageInspector(int index, List<int> afterReceiveRequestOrder, List<int> beforeSendReplyOrder)
+            : this(index, afterReceiveRequestOrder, beforeSendReplyOrder, new object())
+        {
+        }
+
+        public OrderedCallbackDispatchMessageInspector(
+            int index,
+            List<int> afterReceiveRequestOrder,
+            List<int> beforeSendReplyOrder,
+            object correlationState)
+        {
+            _index = index;
+            _afterReceiveRequestOrder = afterReceiveRequestOrder;
+            _beforeSendReplyOrder = beforeSendReplyOrder;
+            CorrelationState = correlationState;
+        }
+
+        public object CorrelationState { get; }
+
+        public object CorrelationStateReturned { get; private set; }
+
+        public object CorrelationStateSeen { get; private set; }
+
+        public object AfterReceiveRequest(ref Message request, IClientChannel channel, InstanceContext instanceContext)
+        {
+            _afterReceiveRequestOrder.Add(_index);
+            CorrelationStateReturned = CorrelationState;
+            return CorrelationState;
+        }
+
+        public void BeforeSendReply(ref Message reply, object correlationState)
+        {
+            _beforeSendReplyOrder.Add(_index);
+            CorrelationStateSeen = correlationState;
+        }
+    }
+
+    private sealed class CallbackDispatchInspectorBehavior : IEndpointBehavior
+    {
+        private const BindingFlags InstanceMembers = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        private readonly bool _addParameterInspector;
+
+        public CallbackDispatchInspectorBehavior(bool addParameterInspector)
+        {
+            _addParameterInspector = addParameterInspector;
+        }
+
+        public CallbackDispatchMessageInspector MessageInspector { get; } = new CallbackDispatchMessageInspector();
+
+        public CallbackDispatchParameterInspector ParameterInspector { get; } = new CallbackDispatchParameterInspector();
+
+        public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+        {
+        }
+
+        public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+        {
+            DispatchRuntime callbackDispatchRuntime = clientRuntime.CallbackDispatchRuntime;
+            callbackDispatchRuntime.MessageInspectors.Add(MessageInspector);
+
+            if (_addParameterInspector)
+            {
+                AddParameterInspector(callbackDispatchRuntime, ParameterInspector);
+            }
+        }
+
+        public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+        {
+        }
+
+        public void Validate(ServiceEndpoint endpoint)
+        {
+        }
+
+        private static void AddParameterInspector(DispatchRuntime callbackDispatchRuntime, IParameterInspector inspector)
+        {
+            PropertyInfo operationsProperty = typeof(DispatchRuntime).GetProperty("Operations", InstanceMembers);
+            Assert.NotNull(operationsProperty);
+
+            IEnumerable operations = operationsProperty.GetValue(callbackDispatchRuntime) as IEnumerable;
+            Assert.NotNull(operations);
+
+            int operationCount = 0;
+            foreach (object operation in operations)
+            {
+                PropertyInfo parameterInspectorsProperty = operation.GetType().GetProperty("ParameterInspectors", InstanceMembers);
+                Assert.NotNull(parameterInspectorsProperty);
+
+                object parameterInspectors = parameterInspectorsProperty.GetValue(operation);
+                Assert.NotNull(parameterInspectors);
+
+                MethodInfo addMethod = parameterInspectors.GetType().GetMethod("Add", new Type[] { typeof(IParameterInspector) });
+                Assert.NotNull(addMethod);
+
+                addMethod.Invoke(parameterInspectors, new object[] { inspector });
+                operationCount++;
+            }
+
+            Assert.True(operationCount > 0);
+        }
+    }
+
+    private sealed class CallbackDispatchMessageInspector : IDispatchMessageInspector
+    {
+        public object CorrelationState { get; } = new object();
+
+        public bool AfterReceiveRequestCalled { get; private set; }
+
+        public bool BeforeSendReplyCalled { get; private set; }
+
+        public object CorrelationStateSeen { get; private set; }
+
+        public object AfterReceiveRequest(ref Message request, IClientChannel channel, InstanceContext instanceContext)
+        {
+            AfterReceiveRequestCalled = true;
+            return CorrelationState;
+        }
+
+        public void BeforeSendReply(ref Message reply, object correlationState)
+        {
+            BeforeSendReplyCalled = true;
+            CorrelationStateSeen = correlationState;
+        }
+    }
+
+    private sealed class CallbackDispatchParameterInspector : IParameterInspector
+    {
+        public object CorrelationState { get; } = new object();
+
+        public bool BeforeCallCalled { get; private set; }
+
+        public bool AfterCallCalled { get; private set; }
+
+        public object CorrelationStateSeen { get; private set; }
+
+        public object BeforeCall(string operationName, object[] inputs)
+        {
+            BeforeCallCalled = true;
+            return CorrelationState;
+        }
+
+        public void AfterCall(string operationName, object[] outputs, object returnValue, object correlationState)
+        {
+            AfterCallCalled = true;
+            CorrelationStateSeen = correlationState;
         }
     }
 }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/DispatchOperationRuntime.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/DispatchOperationRuntime.cs
@@ -129,10 +129,11 @@ namespace System.ServiceModel.Dispatcher
 
         private void InspectInputsCore(ref MessageRpc rpc)
         {
+            int offset = Parent.ParameterInspectorCorrelationOffset;
             for (int i = 0; i < ParameterInspectors.Length; i++)
             {
                 IParameterInspector inspector = ParameterInspectors[i];
-                rpc.Correlation[i] = inspector.BeforeCall(Name, rpc.InputParameters);
+                rpc.Correlation[offset + i] = inspector.BeforeCall(Name, rpc.InputParameters);
                 if (WcfEventSource.Instance.ParameterInspectorBeforeCallInvokedIsEnabled())
                 {
                     WcfEventSource.Instance.ParameterInspectorBeforeCallInvoked(rpc.EventTraceActivity, ParameterInspectors[i].GetType().FullName);
@@ -150,10 +151,11 @@ namespace System.ServiceModel.Dispatcher
 
         private void InspectOutputsCore(ref MessageRpc rpc)
         {
+            int offset = Parent.ParameterInspectorCorrelationOffset;
             for (int i = ParameterInspectors.Length - 1; i >= 0; i--)
             {
                 IParameterInspector inspector = ParameterInspectors[i];
-                inspector.AfterCall(Name, rpc.OutputParameters, rpc.ReturnParameter, rpc.Correlation[i]);
+                inspector.AfterCall(Name, rpc.OutputParameters, rpc.ReturnParameter, rpc.Correlation[offset + i]);
                 if (WcfEventSource.Instance.ParameterInspectorAfterCallInvokedIsEnabled())
                 {
                     WcfEventSource.Instance.ParameterInspectorAfterCallInvoked(rpc.EventTraceActivity, ParameterInspectors[i].GetType().FullName);

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/ImmutableDispatchRuntime.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Dispatcher/ImmutableDispatchRuntime.cs
@@ -49,7 +49,7 @@ namespace System.ServiceModel.Dispatcher
             _terminate = TerminatingOperationBehavior.CreateIfNecessary(dispatch);
             _thread = new ThreadBehavior(dispatch);
             _sendAsynchronously = dispatch.ChannelDispatcher.SendAsynchronously;
-            CorrelationCount = dispatch.MaxParameterInspectors;
+            CorrelationCount = _messageInspectors.Length + dispatch.MaxParameterInspectors;
 
             DispatchOperationRuntime unhandled = new DispatchOperationRuntime(dispatch.UnhandledDispatchOperation, this);
 
@@ -89,6 +89,8 @@ namespace System.ServiceModel.Dispatcher
         internal bool ValidateMustUnderstand { get; }
 
         internal int MessageInspectorCorrelationOffset => 0;
+
+        internal int ParameterInspectorCorrelationOffset => _messageInspectors.Length;
 
         internal void AfterReceiveRequest(ref MessageRpc rpc)
         {


### PR DESCRIPTION
## Summary
- include callback dispatch message inspectors when sizing the per-message correlation array
- place parameter-inspector correlation state after message-inspector state to prevent aliasing
- add duplex callback regressions covering the bounds failure, state aliasing, multiple-inspector order and identity, and null correlation states

Fixes #5969

## Testing
- `System.ServiceModel.Primitives.Tests`: 304 passed, 5 skipped
- targeted callback dispatch integration tests: 4 passed
- confirmed the original bounds and aliasing regressions fail against the unfixed source and pass with this change
- confirmed intentional client and callback correlation-index swaps are detected by the new multiple-inspector tests
- confirmed the issue repro on System.ServiceModel 8.1.2 and 10.0.652802, and verified both defects disappear against the fixed local build