### PR TITLE
[dotnet-svcutil] roll forward to newer major runtimes

### DIFF
--- a/src/dotnet-svcutil/src/dotnet-svcutil.csproj
+++ b/src/dotnet-svcutil/src/dotnet-svcutil.csproj
@@ -21,7 +21,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <!-- Keep one baseline tool asset and roll forward only when its runtime isn't installed. -->
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <RootNamespace>Microsoft.Tools.ServiceModel.Svcutil</RootNamespace>
 
     <PackAsTool>true</PackAsTool>
@@ -31,17 +33,8 @@
 
   <Target Name="PackAdditonalDlls" AfterTargets="build">
     <ItemGroup>
-      <TargetFrameworkItems Include="$(TargetFrameworks)" />
-    </ItemGroup>
-    <ItemGroup>
-      <TargetFrameworkItem Include="%(TargetFrameworkItems.Identity)">
-        <Tfx>%(TargetFrameworkItems.Identity)</Tfx>
-      </TargetFrameworkItem>
-    </ItemGroup>
-    <ItemGroup>      
-      <None Include="$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)\'))\Microsoft.Svcutil.NamedPipeMetadataImporter\$(Configuration)\net6.0\*.dll" Pack="true" PackagePath="tools\%(TargetFrameworkItem.Tfx)\any\net6.0"/>
-      <None Include="$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)\'))\Microsoft.Svcutil.NamedPipeMetadataImporter\$(Configuration)\net8.0\*.dll" Pack="true" PackagePath="tools\%(TargetFrameworkItem.Tfx)\any\net8.0"/>
-      <None Include="$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)\'))\Microsoft.Svcutil.NamedPipeMetadataImporter\$(Configuration)\net462\*.dll" Pack="true" PackagePath="tools\%(TargetFrameworkItem.Tfx)\any\net462"/>
+      <None Include="$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)\'))\Microsoft.Svcutil.NamedPipeMetadataImporter\$(Configuration)\net8.0\*.dll" Pack="true" PackagePath="tools\$(TargetFramework)\any\net8.0"/>
+      <None Include="$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)\'))\Microsoft.Svcutil.NamedPipeMetadataImporter\$(Configuration)\net462\*.dll" Pack="true" PackagePath="tools\$(TargetFramework)\any\net462"/>
     </ItemGroup>
   </Target>
   


### PR DESCRIPTION
Fixes #5972

## Changes

- Target `dotnet-svcutil` with a single `net8.0` tool asset instead of adding a new asset for each .NET major version.
- Set `RollForward` to `Major`, allowing the tool to run when only a newer major runtime is installed while continuing to prefer .NET 8 when it is available.
- Simplify the additional package asset paths for the single target framework.
- Remove the stale `net6.0` NamedPipe metadata importer packaging entry; support for that importer target was removed in PR #5805.

`Major` is intentional rather than `LatestMajor`: `LatestMajor` would always select the newest installed runtime, even when the targeted .NET 8 runtime is present.

## Test coverage follow-up

The bootstrapper `<Content>` baseline lines are currently excluded from comparison. PR #5052 enables comparison of those lines and adds TFM normalization; after this change is merged, those baselines should be updated there to use `DOTNET_VERSION`.