### PR TITLE
Add WCF C# code style Copilot skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,42 @@ $env:PATH = "$env:DOTNET_ROOT;$env:PATH"
 
 Then standard `dotnet build`, `dotnet test`, etc. will work against individual projects.
 
+## Mandatory C# Code Style Skill
+
+For every task that creates, modifies, reviews, formats, ports, or modernizes
+C# code or C# tests, automatically load and follow
+`.github/skills/wcf-csharp-style/SKILL.md` before editing and again before final
+validation.
+
+Non-negotiable formatting scope:
+
+- Apply style only to new or intentionally modified code.
+- Never run solution-wide or repository-wide formatting automatically.
+- `dotnet format` is file-scoped, not line-scoped. Verify all changed C# files,
+  but automatically apply whole-file formatting only to new files.
+- Format existing modified files in the touched hunks, then inspect the diff for
+  unrelated formatter churn.
+- Do not hand-format generated, reference-assembly, baseline, build-output, or
+  Arcade-managed files.
+- Preserve behavior, public API, serialization, threading, ordering, disposal,
+  resources, and exception behavior.
+
+Use the skill helpers from the repository root:
+
+```powershell
+# List eligible changed C# files
+pwsh .github/skills/wcf-csharp-style/scripts/Get-ChangedCSharpFiles.ps1
+
+# Verify formatting without writing files
+pwsh .github/skills/wcf-csharp-style/scripts/Invoke-ChangedCSharpFormat.ps1 -VerifyOnly
+
+# Apply whole-file formatting to new C# files only
+pwsh .github/skills/wcf-csharp-style/scripts/Invoke-ChangedCSharpFormat.ps1 -Apply
+```
+
+Do not use `-AllowModifiedFiles` unless the user explicitly authorizes
+whole-file formatting of existing modified files.
+
 ### Running tests
 
 **Unit tests** (no network required):
@@ -126,9 +162,15 @@ These attributes live in `src/System.Private.ServiceModel/tests/Common/Infrastru
 
 - Braces on new lines (Allman style) for all constructs
 - `using` directives outside namespace
-- Avoid `var` — use explicit types (even when type is apparent, it's only a suggestion)
+- Use `var` when the declaration names the exact type, such as
+  `var factory = new ChannelFactory()`; use an explicit type when a method call
+  or complex expression hides the result type
 - Avoid `this.` qualification
+- Prefer expression-bodied `=>` members for simple single-expression returns
 - Use language keywords over BCL type names (`int` not `Int32`)
+- Keep exactly one blank line after a C# license header
+- Keep one blank line after a completed control-flow block before the next
+  same-scope statement, except before `else`, `catch`, `finally`, or `}`
 - File header required: `Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license.`
 
 ### Multi-targeting

--- a/.github/skills/wcf-csharp-style/SKILL.md
+++ b/.github/skills/wcf-csharp-style/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: wcf-csharp-style
+description: >-
+  Use this skill whenever creating, editing, reviewing, porting, modernizing,
+  or formatting C# code or C# tests in dotnet/wcf. Applies repository code
+  style, legacy-porting safeguards, analyzer guidance, and changed-code-only
+  formatting. Use for implementation work, test changes, PR cleanup, code
+  review, analyzer fixes, and .NET Framework ports. Never mass-format existing
+  source or hand-format generated, reference, or baseline files.
+license: MIT
+compatibility: Requires git and a .NET SDK. Optional helper scripts use PowerShell.
+metadata:
+  audience: coding-agents
+  scope: dotnet-wcf-csharp
+---
+
+# WCF C# Style
+
+Apply consistent C# style without creating unrelated formatting churn or
+changing behavior.
+
+## Automatic Use
+
+Use this skill before editing and again before final validation whenever a task
+creates, modifies, reviews, ports, or formats C# code.
+
+Load only the reference files needed for the current task:
+
+| Task | Read |
+| --- | --- |
+| Normal C# implementation or review | `references/code-style.md` |
+| Unit or scenario tests | `references/testing.md` |
+| .NET Framework port or modernization | `references/modernization.md` |
+| Formatting, generated files, or diff scope | `references/scope-and-formatting.md` |
+
+## When Not to Use
+
+Do not use this skill to:
+
+- Reformat the repository, solution, project, or directory wholesale.
+- Clean up unrelated legacy code in a file being edited.
+- Hand-edit generated, reference-assembly, or baseline output.
+- Make a public API, serialization, threading, or protocol change under the
+  label of formatting.
+- Replace project-specific exception, resource, tracing, or test helpers solely
+  with newer syntax.
+
+## Inputs
+
+| Input | Required | Description |
+| --- | --- | --- |
+| Target files or feature area | Yes | Files that will be created, changed, or reviewed |
+| Mode | No | `pre-edit`, `post-edit`, or `review`; default is both pre- and post-edit |
+| Base ref | No | Branch comparison base, normally `upstream/main` or `origin/main` |
+| Validation scope | No | Smallest affected project and focused tests |
+
+## Authority Order
+
+Apply guidance in this order:
+
+1. Owning project configuration and target frameworks.
+2. Root and nested `.editorconfig` files.
+3. Repository Copilot instructions.
+4. Established style in nearby maintained source.
+5. This skill and its references.
+
+If the target project uses an older language version, do not introduce syntax
+that it cannot compile.
+
+## Non-Negotiable Scope Rules
+
+1. Modify only files required by the task.
+2. Within an existing file, format only new or intentionally modified code.
+3. Never run solution-wide `dotnet format` without explicit user approval.
+4. Never accept formatter-only changes outside intended hunks.
+5. Do not hand-format generated, reference, baseline, or imported build output.
+6. Preserve behavior, public API, wire contracts, serialization, threading,
+   locking, ordering, correlation indexes, disposal, and exception behavior.
+7. Inspect the final diff for unrelated whitespace or line-ending changes.
+
+`dotnet format` operates on complete files, not changed line ranges. The helper
+scripts therefore:
+
+- Verify all changed C# files without writing by default.
+- Apply whole-file formatting automatically only to new C# files.
+- Require an explicit override before applying to modified existing files.
+
+## Pre-Edit Workflow
+
+### 1. Inspect the target
+
+Before editing:
+
+1. Read `.editorconfig` and the owning project file.
+2. Check the project's target frameworks and language version.
+3. Determine whether the file is generated, shared, a reference surface, or a
+   baseline.
+4. Read representative nearby files.
+5. Identify the smallest build and test projects that cover the change.
+
+### 2. Determine current C# scope
+
+```powershell
+pwsh .github/skills/wcf-csharp-style/scripts/Get-ChangedCSharpFiles.ps1
+```
+
+For branch work, provide the intended base explicitly:
+
+```powershell
+pwsh .github/skills/wcf-csharp-style/scripts/Get-ChangedCSharpFiles.ps1 `
+  -BaseRef upstream/main
+```
+
+An empty result means there is no current C# formatting scope. Do not fall back
+to formatting the solution.
+
+### 3. Load the relevant rules
+
+- Read `references/code-style.md` for normal source work.
+- Also read `references/testing.md` when tests are touched.
+- Also read `references/modernization.md` for ported or legacy code.
+- Read `references/scope-and-formatting.md` before running a formatter.
+
+## Apply Style While Editing
+
+Use these high-frequency rules during implementation:
+
+- Keep the required license header, followed by exactly one blank line.
+- Use four spaces, Allman braces, and no trailing whitespace.
+- Keep one blank line after a completed control-flow block before the next
+  same-scope statement, except before `else`, `catch`, `finally`, or `}`.
+- Place usings outside the namespace and sort `System.*` first.
+- Use `_camelCase` instance fields, `s_camelCase` static fields, and PascalCase
+  constants.
+- Omit unnecessary `this.`.
+- Use `var` when the right-hand side names the exact type, such as
+  `new ChannelFactory()`.
+- Use an explicit type when a method call or complex expression hides the
+  result type.
+- Target-typed `new()` is clear when the left-hand type is explicit.
+- Prefer auto-properties only for pure storage.
+- Prefer `=>` for a simple getter or single-expression member.
+- Keep block bodies for validation, tracing, locking, laziness, or multiple
+  operations.
+- Use language keywords and `nameof` when supported.
+- Follow nullable annotations and do not hide warnings with unjustified `!`.
+- Observe every task; do not use `.Result` or `.Wait()` in async flows.
+- Follow the owning component's exception, resource, tracing, and cleanup
+  helpers.
+- Preserve explicit loops where order, indexes, allocations, or mutation
+  matter.
+
+The topical references contain the full rules and examples.
+
+## Changed-Code-Only Formatting
+
+### Verify changed C# files
+
+Verification is the safe default:
+
+```powershell
+pwsh .github/skills/wcf-csharp-style/scripts/Invoke-ChangedCSharpFormat.ps1 `
+  -VerifyOnly `
+  -BaseRef upstream/main
+```
+
+The script uses `dotnet format` with an explicit changed-file list and
+`--verify-no-changes`. It never writes in verification mode.
+
+Changed files are grouped into the main client solution, `dotnet-svcutil`
+solution, or XML serializer solution. Use `-Workspace <solution>` only when a
+different owning workspace is known.
+
+### Apply formatting to new files
+
+Whole-file formatting is safe for newly added files:
+
+```powershell
+pwsh .github/skills/wcf-csharp-style/scripts/Invoke-ChangedCSharpFormat.ps1 `
+  -Apply `
+  -BaseRef upstream/main
+```
+
+By default, `-Apply` skips modified existing files.
+
+### Modified existing files
+
+For modified existing files:
+
+1. Format the new or changed hunks while editing.
+2. Run verification against the changed-file set.
+3. Review diagnostics in the context of the touched lines.
+4. Make targeted fixes with precise edits.
+5. Inspect `git diff` and reject unrelated formatter churn.
+
+Do not automatically use `-AllowModifiedFiles`. That switch is reserved for an
+explicit user request to allow whole-file formatting of already modified files.
+
+### Formatting categories
+
+The formatter helper accepts:
+
+- `All` - whitespace, style, and analyzers.
+- `Whitespace`
+- `Style`
+- `Analyzers`
+
+Use `All` for final verification. Use a narrower category when diagnosing or
+applying a specific class of change.
+
+## Exclusions
+
+The changed-file script excludes these by default:
+
+- Reference assembly directories and generated reference source.
+- Build outputs and local SDK directories.
+- Generated assembly information and generated C# naming patterns.
+- `.notsupported.cs` and `AsmOffsets.cs`.
+- Tool baselines and fixture input trees.
+- Arcade-managed `eng/common` content.
+
+If an API or generated artifact intentionally needs an update, use its owning
+generation process. Do not bypass exclusions merely to make it look formatted.
+
+## Validation
+
+After editing:
+
+1. Run `git diff --check`.
+2. Run changed-file formatting verification.
+3. Inspect `git diff --stat` and the full diff.
+4. Confirm no excluded or unrelated files changed.
+5. Build the smallest affected project.
+6. Run the smallest focused test set.
+7. Check the test count and skipped tests.
+8. Expand validation only when the change is shared or cross-cutting.
+
+Typical targeted flow after restore:
+
+```powershell
+dotnet build <affected-project.csproj> --no-restore
+dotnet test <affected-tests.csproj> --no-build --no-restore `
+  --filter "FullyQualifiedName~RelevantArea"
+```
+
+Use repository build scripts when they are required to bootstrap the local SDK
+or test infrastructure.
+
+## Review Mode
+
+When reviewing code:
+
+1. Determine the changed files and hunks.
+2. Apply the same style rules without requesting unrelated cleanup.
+3. Report style issues only when they are in changed code or directly required
+   for correctness.
+4. Distinguish analyzer-enforced issues from advisory preferences.
+5. Do not propose public API or behavior changes as style fixes.
+
+## Stop and Ask
+
+Request guidance when:
+
+- Public API or reference-surface ownership is unclear.
+- A formatter wants to change untouched legacy lines.
+- The target language version or framework support is unclear.
+- Serialization, interop, locking, ordering, or disposal might change.
+- A generated or baseline file appears to require hand editing.
+- Multiple established styles conflict in the target component.
+
+## Completion Report
+
+Report:
+
+- Files created or modified.
+- References loaded.
+- Formatting mode and exact scope.
+- Excluded or skipped files.
+- Build and tests run.
+- Any style exception or unresolved warning.

--- a/.github/skills/wcf-csharp-style/references/code-style.md
+++ b/.github/skills/wcf-csharp-style/references/code-style.md
@@ -1,0 +1,560 @@
+# C# Style Rules
+
+Use these rules for new or intentionally modified C# code. Do not reformat
+unrelated legacy code.
+
+## Formatting
+
+### Indentation
+
+- Use spaces, not tabs.
+- Use four spaces for C#.
+- Do not align declarations with large runs of spaces.
+- Remove trailing whitespace.
+- End files with a newline.
+- Preserve the existing file's line endings.
+
+### Braces
+
+Use Allman braces and always brace control-flow bodies.
+
+```csharp
+if (isEnabled)
+{
+    Process();
+}
+else
+{
+    Stop();
+}
+```
+
+Do not write:
+
+```csharp
+if (isEnabled)
+    Process();
+```
+
+### Blank lines
+
+- Keep one blank line between members.
+- Use blank lines to separate logical steps.
+- Avoid multiple consecutive blank lines.
+- After a completed control-flow block, keep one blank line before the next
+  statement at the same scope.
+- Do not add that blank line before `else`, `catch`, `finally`, or `}`.
+
+Good:
+
+```csharp
+if (count > 0)
+{
+    Process(first, second);
+}
+
+Target value = (Target)source;
+```
+
+Avoid:
+
+```csharp
+if (count > 0)
+{
+    Process(first, second);
+}
+Target value = (Target)source;
+```
+
+### Spacing
+
+- Use one space after control-flow keywords.
+- Use spaces around binary operators.
+- Use one space after commas.
+- Do not use spaces inside parentheses or brackets.
+- Do not add a space between a method name and `(`.
+- Do not add a space after a cast.
+
+Good:
+
+```csharp
+if (count > 0)
+{
+    Process(first, second);
+}
+
+Target value = (Target)source;
+```
+
+Avoid:
+
+```csharp
+if(count>0)
+{
+    Process ( first , second );
+}
+```
+
+## File Structure
+
+### License header
+
+- Preserve the required license header.
+- If the file begins with a license or copyright block, keep exactly one blank
+  line after the final comment line.
+- The first using, namespace, attribute, or declaration follows that single
+  blank line.
+
+```csharp
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+```
+
+### Usings
+
+- Place usings outside the namespace.
+- Put `System.*` namespaces first.
+- Sort consistently.
+- Remove unused usings.
+- Use one directive per line.
+
+### Namespaces
+
+- Follow the owning project's namespace style.
+- Preserve block-scoped namespaces in existing files.
+- Use file-scoped namespaces for new files only when the component clearly
+  permits them.
+- Do not mass-convert namespace style.
+
+### Member order
+
+Use this general order:
+
+1. Constants.
+2. Static fields.
+3. Instance fields.
+4. Constructors.
+5. Events.
+6. Properties.
+7. Public and internal methods.
+8. Private helpers.
+9. Nested types.
+
+## Naming and Modifiers
+
+| Symbol | Style |
+| --- | --- |
+| Namespace, type, method, property, event | PascalCase |
+| Interface | `I` + PascalCase |
+| Parameter and local | camelCase |
+| Constant | PascalCase |
+| Private/internal instance field | `_camelCase` |
+| Private/internal static field | `s_camelCase` |
+| Type parameter | `T` or descriptive `TName` |
+
+Use positive boolean names such as `isEnabled`, `hasValue`, and `canRetry`.
+
+State accessibility explicitly:
+
+```csharp
+private static void Validate()
+{
+}
+```
+
+Use a consistent modifier order:
+
+```text
+public, private, protected, internal, static, extern, new, virtual,
+abstract, sealed, override, readonly, unsafe, volatile, async
+```
+
+Use readonly fields when they are assigned only during initialization. Do not
+use readonly when mutation is intentional through `ref`, `Interlocked`, lazy
+initialization, pooling, or serialization.
+
+Make utility classes static. Seal internal implementation types when
+inheritance is not required. Do not seal public extension points without API
+review.
+
+## Avoid Unnecessary `this.`
+
+Before:
+
+```csharp
+this._items.Add(item);
+return this.CreateResult();
+```
+
+After:
+
+```csharp
+_items.Add(item);
+return CreateResult();
+```
+
+Use `this.` only to resolve real ambiguity or when required by the language.
+
+## Local Types and Object Creation
+
+Make the type obvious at the declaration.
+
+Use `var` when the right-hand side names the exact type:
+
+```csharp
+var factory = new ChannelFactory();
+var lookup = new Dictionary<string, object>();
+```
+
+Avoid redundant repetition:
+
+```csharp
+ChannelFactory factory = new ChannelFactory();
+```
+
+An explicit type with target-typed `new()` is also clear:
+
+```csharp
+Dictionary<string, object> properties = new();
+```
+
+Use an explicit type when a method call or complex expression hides the result:
+
+```csharp
+Result result = GetResult();
+ProcessResult value = service.Process();
+```
+
+Avoid:
+
+```csharp
+var result = GetResult();
+var value = service.Process();
+```
+
+Use language keywords:
+
+```csharp
+int count;
+string name;
+bool isEnabled;
+object value;
+```
+
+Use `nameof` for parameter and member names when supported:
+
+```csharp
+throw new ArgumentNullException(nameof(value));
+```
+
+Do not use `nameof` for user-visible messages, protocol values, serialized
+names, or configuration keys.
+
+Use reusable empty values when identity is not important:
+
+```csharp
+return Array.Empty<object>();
+```
+
+## Properties and Fields
+
+### Auto-properties
+
+Use auto-properties for pure storage.
+
+Before:
+
+```csharp
+private bool _isEnabled;
+
+public bool IsEnabled
+{
+    get { return _isEnabled; }
+    set { _isEnabled = value; }
+}
+```
+
+After:
+
+```csharp
+public bool IsEnabled { get; set; }
+```
+
+Keep a backing field when it:
+
+- validates or normalizes values
+- delegates to another object
+- performs tracing
+- invalidates a cache
+- is lazily initialized
+- is synchronized, volatile, or accessed through `Interlocked`
+- is passed by `ref`
+- is a lock object
+- has field-level attributes
+- affects serialization, reflection, or interop layout
+- records whether a value was explicitly set
+- preserves a specific exception path
+
+### Expression bodies
+
+Prefer `=>` for a simple getter or single-expression member.
+
+Before:
+
+```csharp
+public int ReceiveRetryCount
+{
+    get { return _receiveRetryCount; }
+}
+```
+
+After:
+
+```csharp
+public int ReceiveRetryCount => _receiveRetryCount;
+```
+
+Fixed values use the same style:
+
+```csharp
+public DeliveryGuarantee Guarantee => DeliveryGuarantee.ExactlyOnce;
+```
+
+Simple accessors may use:
+
+```csharp
+public int ReceiveRetryCount
+{
+    get => _receiveRetryCount;
+    set => _receiveRetryCount = value;
+}
+```
+
+Keep block bodies for validation, logging, tracing, locking, lazy
+initialization, comments, or multiple operations.
+
+Properties should be quick, deterministic, and free of surprising side
+effects. Use methods for expensive or state-changing operations.
+
+## Nullability and Validation
+
+Follow the project's nullable configuration.
+
+- Use `?` only when null is valid.
+- Initialize non-nullable members before use.
+- Validate values entering through configuration, reflection, serialization,
+  interop, dependency injection, or unannotated assemblies.
+- Do not add redundant checks solely to silence uncertainty.
+- Use `!` only when an invariant is proven and cannot be expressed safely.
+- Do not change public nullable annotations without compatibility review.
+
+Prefer reference-pattern checks when testing reference identity:
+
+```csharp
+if (value is null)
+{
+    throw new ArgumentNullException(nameof(value));
+}
+```
+
+Use `== null` or `!= null` when overloaded equality semantics are intentionally
+required. Do not mechanically replace existing null comparisons on custom
+types without checking their operators.
+
+Use the component's existing validation and exception helpers. Do not replace
+them merely to use a newer API.
+
+Use null propagation and coalescing when clear:
+
+```csharp
+scope?.Dispose();
+string displayName = name ?? string.Empty;
+```
+
+Use throw expressions for simple constructor assignment:
+
+```csharp
+_binding = binding ?? throw new ArgumentNullException(nameof(binding));
+```
+
+Use a normal guard block when validation needs tracing, formatting, or several
+steps.
+
+## Exceptions, Resources, and Logging
+
+Preserve exception type, parameter name, resource message, wrapping, stack
+behavior, fatal filtering, and tracing.
+
+Rethrow with:
+
+```csharp
+catch
+{
+    throw;
+}
+```
+
+Never use `throw exception;` to rethrow the current exception.
+
+- Catch only exceptions that can be handled.
+- Do not add broad catches that hide failure.
+- Do not return a success-shaped fallback after an unexpected exception.
+- Keep user-visible text in the component's resource system.
+- Format a resource only when it has placeholders.
+- Do not replace project exception or resource helpers solely for style.
+
+Use structured logging:
+
+```csharp
+logger.LogDebug("Accepted connection {ConnectionId}", connectionId);
+```
+
+Avoid interpolated logging in hot paths:
+
+```csharp
+logger.LogDebug($"Accepted connection {connectionId}");
+```
+
+Do not log credentials, tokens, message bodies, or sensitive data. Use cached
+or source-generated logging delegates in hot paths when the component provides
+them.
+
+## Control Flow
+
+- Prefer early returns that reduce nesting.
+- Use pattern matching when it combines a type check and cast.
+- Use switch expressions for direct value mapping.
+- Use switch statements for state machines, tracing, mutations, or complex
+  protocol logic.
+- Avoid nested conditional expressions.
+- Make local functions static when they do not capture state.
+
+Use explicit loops when order, indexes, allocations, mutations, early exit, or
+exception boundaries matter.
+
+```csharp
+for (int i = 0; i < inspectors.Length; i++)
+{
+    states[i] = inspectors[i].CreateState();
+}
+```
+
+Use LINQ for simple queries when it improves readability. Avoid hidden multiple
+enumeration and do not mechanically convert loops.
+
+## Objects, Collections, and Dependency Injection
+
+Use object and collection initializers when clearer.
+
+Choose collection types deliberately:
+
+- `IReadOnlyList<T>` for ordered read-only access.
+- `IReadOnlyCollection<T>` for count and enumeration.
+- `Dictionary<TKey, TValue>` for mutable key lookup.
+- Immutable collections for fixed shared state.
+- Specialized collections when they enforce ordering or validation.
+
+Do not change collection types when callback, middleware, serialization,
+protocol, or correlation order matters.
+
+For dependency injection:
+
+- Prefer constructor injection for required dependencies.
+- Store dependencies in readonly fields or get-only properties.
+- Validate required dependencies.
+- Avoid global service location.
+- Contain framework-required service location at the adapter boundary.
+- Do not dispose dependencies owned by the container.
+
+## Async and Concurrency
+
+- Methods returning `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>` should
+  normally end with `Async`.
+- Do not rename overrides, interface implementations, or public compatibility
+  APIs whose names are fixed.
+- Return `Task` or `Task<T>` by default.
+- Use `ValueTask` only for measured high-frequency or existing ValueTask-based
+  contracts.
+- Avoid `async void` except true event-handler contracts.
+- Do not block with `.Result` or `.Wait()`.
+- Pass cancellation tokens through supported APIs.
+- Observe every task by awaiting, returning, or explicitly routing failures.
+- Do not mass-add or remove `ConfigureAwait(false)`; follow the component's
+  execution-context convention.
+- Preserve public APM compatibility members during modernization.
+- Keep the final return on its own line.
+
+For `TaskCompletionSource`, normally use:
+
+```csharp
+TaskCompletionSource<object?> completion =
+    new(TaskCreationOptions.RunContinuationsAsynchronously);
+```
+
+Use `TrySetResult`, `TrySetException`, and `TrySetCanceled` when completion can
+race. Use explicit synchronization when publishing or replacing shared
+completion state.
+
+Cancellation sources:
+
+- Dispose owned and linked sources.
+- Do not create per-iteration sources without a real need.
+- Do not reuse canceled sources.
+- Preserve the correct token when propagating cancellation.
+
+## Disposal
+
+Use the owning project's using style.
+
+Use a block when disposal must happen before later statements:
+
+```csharp
+using (Stream stream = OpenStream())
+{
+    Process(stream);
+}
+
+ContinueAfterDisposal();
+```
+
+Use a declaration when the resource should live until the scope ends:
+
+```csharp
+using Stream stream = OpenStream();
+Process(stream);
+```
+
+Preserve established close-or-abort patterns for faultable communication
+objects. Do not introduce asynchronous disposal when callers depend on
+synchronous cleanup.
+
+## Platform and Performance Code
+
+- Use platform annotations when available.
+- Use runtime platform checks before platform-specific behavior.
+- Keep interop isolated.
+- Do not suppress platform diagnostics without a real guard.
+
+Use allocation-focused features only in measured hot paths:
+
+- cache static delegates
+- use static lambdas when no capture is needed
+- use spans and memory only with clear lifetime rules
+- use `stackalloc` only for small bounded buffers
+- never stack-allocate a size controlled by untrusted input
+- avoid unnecessary sequence copies
+- document non-obvious lifetime and pooling rules
+
+Do not introduce spans, pooling, or caches without measurements showing the
+allocation matters.
+
+## Comments and Documentation
+
+- Explain why, not what the code already states.
+- Remove commented-out code and unused helpers.
+- Fix stale or incorrect comments.
+- Preserve compatibility, threading, security, and protocol explanations.
+- Use XML documentation for public APIs when required.
+- Use regions sparingly; do not hide an oversized type with regions.

--- a/.github/skills/wcf-csharp-style/references/modernization.md
+++ b/.github/skills/wcf-csharp-style/references/modernization.md
@@ -1,0 +1,166 @@
+# Legacy Porting and Modernization
+
+Use this reference when porting .NET Framework code or modernizing legacy C#.
+
+Modernization must preserve behavior. Newer syntax is not automatically better.
+
+## Stage 1: Understand the Contract
+
+Before editing, identify:
+
+- public and explicit interface API
+- reference-assembly ownership
+- serialization and interop shape
+- protocol and wire behavior
+- exception types and messages
+- threading, locks, and lazy initialization
+- callback and inspector order
+- correlation indexes
+- disposal and lifetime
+- target frameworks and language version
+- platform conditions
+- resource strings and tracing
+
+Build or run the closest baseline before a large port when practical.
+
+## Stage 2: Port the Minimum Implementation
+
+- Start from the source that matches the intended client behavior.
+- Copy only required types and helpers.
+- Do not port service-host-only implementations into a client library.
+- Preserve public and explicit interface members.
+- Replace unavailable dependencies deliberately.
+- Search for existing helpers before adding new ones.
+- Re-audit helper files after removing unsupported branches.
+
+## Stage 3: Apply Mechanical Style
+
+Candidates include:
+
+| Legacy pattern | Preferred form |
+| --- | --- |
+| `this.field` | `_field` |
+| `private int count;` | `private int _count;` |
+| `private static object cache;` | `private static object s_cache;` |
+| `"parameter"` | `nameof(parameter)` when supported |
+| `new T[0]` | `Array.Empty<T>()` |
+| namespace-scoped usings | file-level usings |
+| unbraced condition | Allman braced block |
+| repeated type in `new Type()` | `var` when the type is obvious |
+| explicit left type plus constructor | target-typed `new()` when supported |
+| dead commented code | delete it |
+
+Every candidate still requires compatibility review.
+
+## Stage 4: Simplify Properties Carefully
+
+Convert a field and property to an auto-property only when the field is pure
+storage.
+
+Do not convert:
+
+- lazy properties
+- validated properties
+- delegated properties
+- synchronized or volatile state
+- serialized or interop fields
+- fields used through reflection
+- fields passed by `ref`
+- fields that record explicit initialization
+- fields that preserve tracing or exception behavior
+
+Use expression-bodied members for simple returns. Keep block bodies for
+behavior.
+
+## Stage 5: Use Modern Language Features Selectively
+
+Consider:
+
+- pattern matching
+- object and collection initializers
+- target-typed `new`
+- expression-bodied members
+- null propagation
+- throw expressions
+- switch expressions
+- Task-based internals
+
+Use a feature only when:
+
+- the target language version supports it
+- every target framework supports required APIs
+- the result is clearer
+- behavior remains unchanged
+
+## Stage 6: Remove Obsolete Patterns
+
+Review:
+
+- obsolete static-analysis suppressions
+- copied framework helpers with maintained equivalents
+- obsolete type forwarding
+- custom pools or caches
+- old APM implementation machinery
+- service-only code in client packages
+- dead compatibility branches
+- stale comments and unused helpers
+
+Do not remove compatibility code until supported scenarios are understood.
+
+## Unsafe Style Transformations
+
+These are not purely stylistic:
+
+- changing public API shape
+- changing nullable public annotations
+- changing property storage semantics
+- changing collection type or ordering
+- replacing loops with LINQ in hot paths
+- changing null comparisons with overloaded operators
+- replacing project exception or resource helpers
+- removing `ref` or `out`
+- changing callback order or array indexes
+- changing lock objects
+- changing lazy initialization
+- changing disposal behavior
+- changing serialization attributes
+- changing interop layout
+- removing compatibility interfaces
+- introducing APIs unsupported by older targets
+
+These changes require separate design and test review.
+
+## Generated and Public API Files
+
+Before editing, determine whether a file is:
+
+- generated
+- reference assembly source
+- baseline or fixture input
+- public API surface
+- imported build content
+- owned by another generator
+
+Do not manually format generated output. Update it through the owning process.
+
+Public API changes must not be hidden inside a style-only change.
+
+## Shared Source
+
+If a source file is compiled into several projects:
+
+1. Find every consumer.
+2. Check each consumer's symbols, language version, and target frameworks.
+3. Build and test all affected consumers.
+
+## Port Completion Checklist
+
+- [ ] Behavior and API shape are preserved.
+- [ ] Unsupported service-host code was not copied into the client.
+- [ ] Field and property conversions are semantically safe.
+- [ ] Exception, resource, tracing, and fatal-filter paths are preserved.
+- [ ] Locks, laziness, ordering, and disposal are unchanged.
+- [ ] Every target framework can compile the syntax and APIs.
+- [ ] Generated and reference files use their owning workflow.
+- [ ] Focused tests cover the ported behavior.
+

--- a/.github/skills/wcf-csharp-style/references/scope-and-formatting.md
+++ b/.github/skills/wcf-csharp-style/references/scope-and-formatting.md
@@ -1,0 +1,167 @@
+# Changed-Code-Only Formatting
+
+Use this reference before running formatting or analyzer fixes.
+
+## Fundamental Limitation
+
+`dotnet format` is file-scoped, not line-scoped. `--include` limits which files
+are processed, but the formatter may change untouched legacy lines inside an
+included modified file.
+
+Therefore:
+
+- Verification can safely target all changed files.
+- Automatic whole-file application is safe by default only for new files.
+- Existing modified files require hunk-level edits and diff review.
+
+## Determine Scope
+
+The helper combines:
+
+- committed branch changes relative to a merge base
+- unstaged tracked changes
+- staged changes
+- untracked C# files
+
+```powershell
+pwsh .github/skills/wcf-csharp-style/scripts/Get-ChangedCSharpFiles.ps1 `
+  -BaseRef upstream/main
+```
+
+It excludes generated, reference, baseline, build-output, and managed
+infrastructure paths by default.
+
+The formatter helper groups changed files into their owning workspace:
+
+- Main client libraries and tests use `System.ServiceModel.sln`.
+- `src/dotnet-svcutil/` uses `dotnet-svcutil.sln`.
+- `src/svcutilcore/` uses `dotnet-svcutil.xmlserializer.sln`.
+
+Use `-Workspace <solution>` to override automatic grouping for a known special
+case.
+
+## Verify
+
+Use verification after manual edits:
+
+```powershell
+pwsh .github/skills/wcf-csharp-style/scripts/Invoke-ChangedCSharpFormat.ps1 `
+  -VerifyOnly `
+  -Category All `
+  -BaseRef upstream/main
+```
+
+Verification uses:
+
+- the repository workspace
+- `--no-restore`
+- an explicit changed-file list
+- `--verify-no-changes`
+
+It does not write files.
+
+## Apply to New Files
+
+```powershell
+pwsh .github/skills/wcf-csharp-style/scripts/Invoke-ChangedCSharpFormat.ps1 `
+  -Apply `
+  -Category All `
+  -BaseRef upstream/main
+```
+
+Default apply mode:
+
+- formats newly added eligible C# files
+- warns about modified existing C# files
+- skips those existing files
+
+## Modified Existing Files
+
+Format modified code while editing:
+
+1. Apply the guide to the changed hunks.
+2. Run verification.
+3. Read diagnostics for the touched code.
+4. Make targeted edits.
+5. Inspect `git diff --word-diff` or a normal patch.
+6. Reject unrelated whitespace and line-ending changes.
+
+Do not run automatic whole-file apply merely because a modified file appears in
+the branch.
+
+The formatter helper exposes `-AllowModifiedFiles`, but agents must not use it
+automatically. Use it only when the user explicitly authorizes whole-file
+formatting and accepts possible legacy churn.
+
+## Exclusions
+
+Default exclusions include:
+
+```text
+**/bin/**
+**/obj/**
+**/.dotnet/**
+**/ref/**
+eng/common/**
+src/dotnet-svcutil/lib/tests/Baselines/**
+src/dotnet-svcutil/lib/tests/TestCases/**
+**/*.g.cs
+**/*.generated.cs
+**/*.designer.cs
+**/*AssemblyInfo.cs
+**/*.notsupported.cs
+**/AsmOffsets.cs
+```
+
+Do not bypass exclusions when:
+
+- the task does not own the generated file
+- the file is a golden baseline
+- a reference surface must be generated
+- the file is managed by shared infrastructure
+
+If an excluded file legitimately needs an update, use the owning process and
+validate the resulting artifact separately.
+
+## Diff Hygiene
+
+After formatting:
+
+```powershell
+git diff --check
+git diff --stat
+git diff
+```
+
+Confirm:
+
+- only intended files changed
+- no unrelated lines were reformatted
+- no generated or baseline files changed unexpectedly
+- no line-ending-only diff appeared
+- comments and behavior were not rewritten by analyzer fixes
+
+## Build and Test
+
+Formatting verification is not compilation verification.
+
+Run:
+
+1. the smallest affected build
+2. focused unit tests
+3. scenario tests only when behavior requires them
+
+Check test counts and skips.
+
+## Failure Handling
+
+If formatting wants to change untouched lines:
+
+1. Do not accept the whole-file result.
+2. Restore or manually reverse only the formatter-created unrelated hunks.
+3. Keep the intended implementation changes.
+4. Apply style directly to the touched code.
+5. Run verification again.
+
+Do not discard the user's implementation changes while cleaning formatter
+output.

--- a/.github/skills/wcf-csharp-style/references/testing.md
+++ b/.github/skills/wcf-csharp-style/references/testing.md
@@ -1,0 +1,116 @@
+# Test Style
+
+Load this reference whenever C# tests or test infrastructure are created,
+modified, reviewed, or ported.
+
+## Follow the Owning Test Project
+
+- Use the test framework and custom attributes already established by the
+  project.
+- Scenario and integration tests use the repository's WCF-aware fact, theory,
+  condition, issue, and outer-loop infrastructure.
+- Package unit-test projects may use standard xUnit attributes where that is
+  the established pattern.
+- Do not mechanically replace custom attributes with plain facts or theories.
+- Add tests to an existing relevant file when practical.
+
+## Names
+
+Use a descriptive pattern such as:
+
+```text
+Member_Condition_ExpectedResult
+```
+
+Scenario-style names are acceptable when they communicate binding, transport,
+configuration, and behavior more clearly.
+
+```csharp
+public async Task HttpRequestReplyEchoString()
+{
+}
+```
+
+## Test Behavior
+
+- Test one clear behavior.
+- Async tests return `Task` or a supported `ValueTask`, never `async void`.
+- Use async assertion APIs for asynchronous failures.
+- Use precise assertions.
+- Verify that the intended path executed.
+- Assert identity when identity matters.
+- Assert invocation order when order matters.
+- Assert argument parameter names when relevant.
+- For faults or protocol failures, assert codes and details, not only the
+  exception type.
+- Avoid arbitrary sleeps.
+- Clean up resources in `finally` or through established helpers.
+- Check filtered test run counts and skipped tests.
+
+Prefer xUnit assertions over throwing generic exceptions from assertion
+helpers.
+
+## Data-Driven Tests
+
+- Use inline data for small constant matrices.
+- Use named member-data factories for complex or non-constant cases.
+- Give data factories scenario-oriented names.
+- Keep each row understandable in failure output.
+
+## Conditions and Platforms
+
+- Prefer project-provided platform, runtime, issue, and skip attributes.
+- Do not repeat ad-hoc operating-system checks in test bodies.
+- Keep skip reasons specific and actionable.
+- Pin culture through test infrastructure for culture-dependent assertions.
+
+## Fixtures and Hosts
+
+- Use existing helpers to create hosts, clients, factories, and service
+  providers.
+- Use class fixtures for expensive per-class setup.
+- Use collection fixtures for exclusive external resources.
+- Inject test output or logging through the test framework.
+- Configure test services through the test host or factory.
+- Do not mutate production global state when a scoped test host can be used.
+- Dispose hosts, clients, scopes, channels, and factories through their
+  established cleanup helpers.
+
+## Timeouts and Determinism
+
+- Prefer ephemeral ports over fixed ports.
+- Await observable state instead of sleeping.
+- Bound asynchronous, network, and external-resource waits with a realistic
+  timeout.
+- Use very short timeouts only when timeout behavior itself is under test.
+- Increase timeouts under a debugger through shared infrastructure.
+- Isolate tests requiring exclusive OS resources or external containers.
+- Capture unexpected server exceptions through test logging.
+- Document known product limitations instead of hiding them with retries.
+
+## Readability
+
+Prefer explicit setup over a highly abstract test DSL.
+
+Do not add comments that only say:
+
+```text
+Arrange
+Act
+Assert
+```
+
+The method name and code should make the phases clear.
+
+## Test Completion Checklist
+
+- [ ] Correct fact/theory and condition attributes are used.
+- [ ] The test name identifies the behavior.
+- [ ] Async work is awaited.
+- [ ] Identity and order are asserted when relevant.
+- [ ] Fault details are asserted when relevant.
+- [ ] No arbitrary sleep is used.
+- [ ] Resources are cleaned up.
+- [ ] The focused filter ran the expected test count.
+- [ ] Platform and culture conditions use shared infrastructure.
+

--- a/.github/skills/wcf-csharp-style/scripts/Get-ChangedCSharpFiles.ps1
+++ b/.github/skills/wcf-csharp-style/scripts/Get-ChangedCSharpFiles.ps1
@@ -1,0 +1,151 @@
+[CmdletBinding()]
+param(
+    [string]$BaseRef,
+    [switch]$NewFilesOnly,
+    [switch]$IncludeExcluded
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-GitLines
+{
+    param([string[]]$Arguments)
+
+    [string[]]$output = @(& git @Arguments)
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+
+    return @($output | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Resolve-BaseCommit
+{
+    param([string]$RequestedBaseRef)
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedBaseRef))
+    {
+        & git rev-parse --verify "$RequestedBaseRef`^{commit}" *> $null
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "Base ref '$RequestedBaseRef' does not resolve to a commit."
+        }
+
+        return (@(Invoke-GitLines @("merge-base", "HEAD", $RequestedBaseRef)))[0].Trim()
+    }
+
+    [string[]]$candidates = @("upstream/main", "origin/main", "main")
+    foreach ($candidate in $candidates)
+    {
+        & git rev-parse --verify "$candidate`^{commit}" *> $null
+        if ($LASTEXITCODE -eq 0)
+        {
+            return (@(Invoke-GitLines @("merge-base", "HEAD", $candidate)))[0].Trim()
+        }
+    }
+
+    return (@(Invoke-GitLines @("rev-parse", "HEAD")))[0].Trim()
+}
+
+function Test-IsExcludedPath
+{
+    param([string]$Path)
+
+    [string]$normalized = $Path.Replace("\", "/")
+    [string]$fileName = [IO.Path]::GetFileName($normalized)
+
+    if ($normalized -match "(^|/)(bin|obj|\.dotnet)(/|$)")
+    {
+        return $true
+    }
+
+    if ($normalized -match "(^|/)ref(/|$)")
+    {
+        return $true
+    }
+
+    if ($normalized -match "^eng/common/")
+    {
+        return $true
+    }
+
+    if ($normalized -match "^src/dotnet-svcutil/lib/tests/(Baselines|TestCases)/")
+    {
+        return $true
+    }
+
+    if ($fileName -match "(\.g|\.generated|\.designer)\.cs$")
+    {
+        return $true
+    }
+
+    if ($fileName -match "(^|_)AssemblyInfo\.cs$")
+    {
+        return $true
+    }
+
+    if ($fileName -eq "AsmOffsets.cs" -or $fileName.EndsWith(".notsupported.cs"))
+    {
+        return $true
+    }
+
+    return $false
+}
+
+[string]$repositoryRoot =
+    (@(Invoke-GitLines @("rev-parse", "--show-toplevel")))[0].Trim()
+
+Push-Location $repositoryRoot
+try
+{
+    [string]$baseCommit = Resolve-BaseCommit -RequestedBaseRef $BaseRef
+    [string]$diffFilter = if ($NewFilesOnly) { "A" } else { "ACMR" }
+
+    [System.Collections.Generic.List[string]]$paths = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($path in (Invoke-GitLines @(
+        "diff", "--name-only", "--diff-filter=$diffFilter",
+        "$baseCommit...HEAD", "--", "*.cs")))
+    {
+        $paths.Add($path)
+    }
+
+    foreach ($path in (Invoke-GitLines @(
+        "diff", "--name-only", "--diff-filter=$diffFilter", "--", "*.cs")))
+    {
+        $paths.Add($path)
+    }
+
+    foreach ($path in (Invoke-GitLines @(
+        "diff", "--cached", "--name-only", "--diff-filter=$diffFilter",
+        "--", "*.cs")))
+    {
+        $paths.Add($path)
+    }
+
+    foreach ($path in (Invoke-GitLines @(
+        "ls-files", "--others", "--exclude-standard", "--", "*.cs")))
+    {
+        $paths.Add($path)
+    }
+
+    [string[]]$uniquePaths = @(
+        $paths |
+            ForEach-Object { $_.Replace("\", "/") } |
+            Sort-Object -Unique
+    )
+
+    foreach ($path in $uniquePaths)
+    {
+        if ($IncludeExcluded -or -not (Test-IsExcludedPath -Path $path))
+        {
+            Write-Output $path
+        }
+    }
+}
+finally
+{
+    Pop-Location
+}

--- a/.github/skills/wcf-csharp-style/scripts/Invoke-ChangedCSharpFormat.ps1
+++ b/.github/skills/wcf-csharp-style/scripts/Invoke-ChangedCSharpFormat.ps1
@@ -1,0 +1,230 @@
+[CmdletBinding()]
+param(
+    [string]$Workspace,
+    [string]$BaseRef,
+    [ValidateSet("All", "Whitespace", "Style", "Analyzers")]
+    [string]$Category = "All",
+    [switch]$VerifyOnly,
+    [switch]$Apply,
+    [switch]$AllowModifiedFiles
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($VerifyOnly -and $Apply)
+{
+    throw "Specify either -VerifyOnly or -Apply, not both."
+}
+
+if (-not $VerifyOnly -and -not $Apply)
+{
+    $VerifyOnly = $true
+}
+
+[string]$scriptRoot = $PSScriptRoot
+[string[]]$repositoryRootOutput = @(& git rev-parse --show-toplevel)
+if ($LASTEXITCODE -ne 0 -or $repositoryRootOutput.Count -eq 0)
+{
+    throw "The current directory is not inside a git repository."
+}
+[string]$repositoryRoot = $repositoryRootOutput[0].Trim()
+
+[string]$getChangedFilesScript = Join-Path $scriptRoot "Get-ChangedCSharpFiles.ps1"
+if (-not (Test-Path -LiteralPath $getChangedFilesScript))
+{
+    throw "Changed-file helper was not found at '$getChangedFilesScript'."
+}
+
+[System.Collections.Generic.List[string]]$allChangedFiles =
+    [System.Collections.Generic.List[string]]::new()
+
+foreach ($path in (& $getChangedFilesScript -BaseRef $BaseRef))
+{
+    $allChangedFiles.Add($path)
+}
+
+if ($allChangedFiles.Count -eq 0)
+{
+    Write-Host "No changed C# files are eligible for formatting."
+    exit 0
+}
+
+[System.Collections.Generic.List[string]]$targetFiles =
+    [System.Collections.Generic.List[string]]::new()
+
+if ($Apply -and -not $AllowModifiedFiles)
+{
+    foreach ($path in (& $getChangedFilesScript -BaseRef $BaseRef -NewFilesOnly))
+    {
+        $targetFiles.Add($path)
+    }
+
+    [string[]]$skippedFiles = @(
+        $allChangedFiles |
+            Where-Object { -not $targetFiles.Contains($_) }
+    )
+
+    if ($skippedFiles.Count -gt 0)
+    {
+        Write-Warning (
+            "dotnet format is file-scoped. Skipping modified existing files " +
+            "in apply mode:`n - " + ($skippedFiles -join "`n - ")
+        )
+        Write-Warning (
+            "Format their changed hunks manually, then run this script with " +
+            "-VerifyOnly. Use -AllowModifiedFiles only when the user explicitly " +
+            "accepts whole-file formatting."
+        )
+    }
+}
+else
+{
+    foreach ($path in $allChangedFiles)
+    {
+        $targetFiles.Add($path)
+    }
+}
+
+if ($targetFiles.Count -eq 0)
+{
+    Write-Host "No safe whole-file apply targets were found."
+    exit 0
+}
+
+[string[]]$localDotnetCandidates = @(
+    (Join-Path $repositoryRoot ".dotnet/dotnet.exe"),
+    (Join-Path $repositoryRoot ".dotnet/dotnet")
+)
+
+[string]$dotnetCommand = $null
+foreach ($candidate in $localDotnetCandidates)
+{
+    if (Test-Path -LiteralPath $candidate)
+    {
+        $dotnetCommand = $candidate
+        break
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($dotnetCommand))
+{
+    [System.Management.Automation.CommandInfo]$dotnet =
+        Get-Command dotnet -ErrorAction SilentlyContinue
+    if ($null -eq $dotnet)
+    {
+        throw "dotnet was not found. Restore the repository toolchain first."
+    }
+
+    $dotnetCommand = $dotnet.Source
+}
+
+function Get-WorkspaceForPath
+{
+    param(
+        [string]$Path,
+        [string]$ExplicitWorkspace
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitWorkspace))
+    {
+        return $ExplicitWorkspace
+    }
+
+    [string]$normalized = $Path.Replace("\", "/")
+    if ($normalized.StartsWith("src/dotnet-svcutil/"))
+    {
+        return "dotnet-svcutil.sln"
+    }
+
+    if ($normalized.StartsWith("src/svcutilcore/"))
+    {
+        return "dotnet-svcutil.xmlserializer.sln"
+    }
+
+    return "System.ServiceModel.sln"
+}
+
+[hashtable]$workspaceGroups = @{}
+foreach ($path in $targetFiles)
+{
+    [string]$workspaceName =
+        Get-WorkspaceForPath -Path $path -ExplicitWorkspace $Workspace
+
+    if (-not $workspaceGroups.ContainsKey($workspaceName))
+    {
+        $workspaceGroups[$workspaceName] =
+            [System.Collections.Generic.List[string]]::new()
+    }
+
+    $workspaceGroups[$workspaceName].Add($path)
+}
+
+Write-Host (
+    "Formatting mode: " +
+    $(if ($VerifyOnly) { "verify" } else { "apply" })
+)
+Write-Host "Category: $Category"
+
+Push-Location $repositoryRoot
+try
+{
+    foreach ($workspaceName in ($workspaceGroups.Keys | Sort-Object))
+    {
+        [string]$workspacePath = if ([IO.Path]::IsPathRooted($workspaceName))
+        {
+            $workspaceName
+        }
+        else
+        {
+            Join-Path $repositoryRoot $workspaceName
+        }
+
+        if (-not (Test-Path -LiteralPath $workspacePath))
+        {
+            throw "Workspace '$workspacePath' does not exist."
+        }
+
+        [System.Collections.Generic.List[string]]$formatArguments =
+            [System.Collections.Generic.List[string]]::new()
+        $formatArguments.Add("format")
+
+        if ($Category -ne "All")
+        {
+            $formatArguments.Add($Category.ToLowerInvariant())
+        }
+
+        $formatArguments.Add($workspacePath)
+        $formatArguments.Add("--no-restore")
+
+        if ($VerifyOnly)
+        {
+            $formatArguments.Add("--verify-no-changes")
+        }
+
+        $formatArguments.Add("--include")
+        foreach ($path in $workspaceGroups[$workspaceName])
+        {
+            $formatArguments.Add($path)
+        }
+
+        Write-Host "Workspace: $workspaceName"
+        Write-Host "Files:"
+        foreach ($path in $workspaceGroups[$workspaceName])
+        {
+            Write-Host " - $path"
+        }
+
+        & $dotnetCommand @formatArguments
+        if ($LASTEXITCODE -ne 0)
+        {
+            exit $LASTEXITCODE
+        }
+    }
+
+    exit 0
+}
+finally
+{
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add a repository-scoped `wcf-csharp-style` Copilot Agent Skill for C# implementation, reviews, tests, and .NET Framework modernization
- add focused references for code style, testing, modernization, and formatting scope
- add PowerShell helpers that discover eligible changed C# files across all three solutions
- update Copilot instructions to load the skill automatically for C# work

## Formatting safety
- verification is limited to changed C# files
- automatic apply formats newly added files only by default
- existing modified files are skipped unless whole-file formatting is explicitly authorized
- generated, reference, baseline, build-output, and Arcade-managed files are excluded

## Validation
- `gh skill publish .github/skills --dry-run`
- parsed both PowerShell helpers successfully
- exercised formatting across `System.ServiceModel.sln`, `dotnet-svcutil.sln`, and `dotnet-svcutil.xmlserializer.sln`
- confirmed apply mode skips modified existing files
- confirmed no existing C# source changed