### PR TITLE
Fix async message contract response unwrapping

### DIFF
--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/CodeDomVisitor.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/CodeDomVisitor.cs
@@ -184,6 +184,12 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 base.Visit(expr);
             }
 
+            protected override void Visit(CodeAwaitExpression expr)
+            {
+                Enumerate(expr.Expression);
+                base.Visit(expr);
+            }
+
             protected override void Visit(CodeDelegateCreateExpression expr)
             {
                 Enumerate(expr.DelegateType);
@@ -588,6 +594,8 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         {
             if (expr is CodeArgumentReferenceExpression)
                 Visit((CodeArgumentReferenceExpression)expr);
+            else if (expr is CodeAwaitExpression)
+                Visit((CodeAwaitExpression)expr);
             else if (expr is CodeArrayCreateExpression)
                 Visit((CodeArrayCreateExpression)expr);
             else if (expr is CodeArrayIndexerExpression)
@@ -643,6 +651,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         }
         #region descendants of CodeExpression
         protected virtual void Visit(CodeArgumentReferenceExpression expr) { }
+        protected virtual void Visit(CodeAwaitExpression expr) { }
         protected virtual void Visit(CodeArrayCreateExpression expr) { }
         protected virtual void Visit(CodeArrayIndexerExpression expr) { }
         protected virtual void Visit(CodeBaseReferenceExpression expr) { }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/Compiler/CodeGenerator.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/Compiler/CodeGenerator.cs
@@ -813,6 +813,10 @@ namespace Microsoft.CodeDom.Compiler
             {
                 GenerateDefaultValueExpression((CodeDefaultValueExpression)e);
             }
+            else if (e is CodeAwaitExpression)
+            {
+                GenerateAwaitExpression((CodeAwaitExpression)e);
+            }
             else
             {
                 if (e == null)
@@ -1830,6 +1834,10 @@ namespace Microsoft.CodeDom.Compiler
 
         // TODO: this should be abstract, but that will break language providers which don't support DefaultValueExpression.
         protected virtual void GenerateDefaultValueExpression(CodeDefaultValueExpression e)
+        {
+        }
+
+        protected virtual void GenerateAwaitExpression(CodeAwaitExpression e)
         {
         }
 

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/Compiler/CodeValidator.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/Compiler/CodeValidator.cs
@@ -742,6 +742,10 @@ namespace Microsoft.CodeDom.Compiler
             {
                 ValidateDefaultValueExpression((CodeDefaultValueExpression)e);
             }
+            else if (e is CodeAwaitExpression)
+            {
+                ValidateExpression(((CodeAwaitExpression)e).Expression);
+            }
             else if (e is CodeDelegateCreateExpression)
             {
                 ValidateDelegateCreateExpression((CodeDelegateCreateExpression)e);

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/Microsoft/CSharpCodeProvider.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/Microsoft/CSharpCodeProvider.cs
@@ -889,6 +889,12 @@ namespace Microsoft.CSharp
             Output.Write(")");
         }
 
+        private void GenerateAwaitExpression(CodeAwaitExpression e)
+        {
+            Output.Write("await ");
+            GenerateExpression(e.Expression);
+        }
+
         /// <devdoc>
         ///    <para>
         ///       Generates code for the specified CodeDom based delegate creation
@@ -1958,6 +1964,10 @@ namespace Microsoft.CSharp
             {
                 GenerateDefaultValueExpression((CodeDefaultValueExpression)e);
             }
+            else if (e is CodeAwaitExpression)
+            {
+                GenerateAwaitExpression((CodeAwaitExpression)e);
+            }
             else
             {
                 if (e == null)
@@ -2120,6 +2130,10 @@ namespace Microsoft.CSharp
                     OutputMemberAccessModifier(e.Attributes);
                     OutputVTableModifier(e.Attributes);
                     OutputMemberScopeModifier(e.Attributes);
+                    if (GetUserData(e, CodeAwaitExpression.AsyncMethodUserDataKey, false))
+                    {
+                        Output.Write("async ");
+                    }
                 }
             }
             else

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/Microsoft/VBCodeProvider.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/Microsoft/VBCodeProvider.cs
@@ -773,6 +773,12 @@ namespace Microsoft.VisualBasic
             Output.Write("CType(Nothing, " + GetTypeOutput(e.Type) + ")");
         }
 
+        protected override void GenerateAwaitExpression(CodeAwaitExpression e)
+        {
+            Output.Write("Await ");
+            GenerateExpression(e.Expression);
+        }
+
         protected override void GenerateDirectionExpression(CodeDirectionExpression e)
         {
             // Visual Basic does not need to adorn the calling point with a direction, so just output the expression.
@@ -2076,6 +2082,11 @@ namespace Microsoft.VisualBasic
             {
                 // interface may still need "Shadows"
                 OutputVTableModifier(e.Attributes);
+            }
+            if (!IsCurrentInterface && e.PrivateImplementationType == null &&
+                GetUserData(e, CodeAwaitExpression.AsyncMethodUserDataKey, false))
+            {
+                Output.Write("Async ");
             }
             bool sub = false;
             if (e.ReturnType.BaseType.Length == 0 || string.Compare(e.ReturnType.BaseType, typeof(void).FullName, StringComparison.OrdinalIgnoreCase) == 0)

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/System/CodeAwaitExpression.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/Microsoft.CodeDom/System/CodeAwaitExpression.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeDom
+{
+    // CodeDOM has no await node, so svcutil uses this expression to emit equivalent C# and VB helpers.
+    public sealed class CodeAwaitExpression : CodeExpression
+    {
+        internal const string AsyncMethodUserDataKey = "Microsoft.CodeDom.AsyncMethod";
+
+        public CodeAwaitExpression(CodeExpression expression)
+        {
+            Expression = expression;
+        }
+
+        public CodeExpression Expression { get; }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Description/ClientClassGenerator.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Description/ClientClassGenerator.cs
@@ -14,6 +14,7 @@ namespace System.ServiceModel.Description
     using System.ServiceModel;
     using System.ServiceModel.Channels;
     using System.Threading;
+    using System.Threading.Tasks;
 
     internal class ClientClassGenerator : IServiceContractGenerationExtension
     {
@@ -259,7 +260,7 @@ namespace System.ServiceModel.Description
             return browsableAttribute;
         }
 
-        private static CodeMemberMethod GenerateHelperMethod(CodeTypeReference ifaceType, CodeMemberMethod method)
+        internal static CodeMemberMethod GenerateHelperMethod(CodeTypeReference ifaceType, CodeMemberMethod method)
         {
             CodeMemberMethod helperMethod = new CodeMemberMethod();
             helperMethod.Name = method.Name;
@@ -287,16 +288,38 @@ namespace System.ServiceModel.Description
                 helperMethod.Statements.Add(invokeMethod);
             else
             {
-                CodeTypeDeclaration returnTypeDecl = ServiceContractGenerator.NamespaceHelper.GetCodeType(method.ReturnType);
-                if (returnTypeDecl != null)
+                CodeTypeReference returnType = method.ReturnType;
+                // A typed response inside Task<T> must be awaited before the existing message-wrapper flattening can inspect it.
+                bool isTask = returnType.BaseType == typeof(Task<>).FullName && returnType.TypeArguments.Count == 1;
+                CodeTypeReference resultType = isTask ? returnType.TypeArguments[0] : returnType;
+                CodeTypeDeclaration returnTypeDecl = ServiceContractGenerator.NamespaceHelper.GetCodeType(resultType);
+                // Async methods cannot expose ref or out parameters, so preserve the wrapper when flattening needs them.
+                bool canUnwrapTaskResult = !isTask || CanUnwrapTaskResult(returnTypeDecl, helperMethod.Parameters);
+                if (returnTypeDecl != null && canUnwrapTaskResult)
                 {
                     hasTypedMessage = true;
                     CodeVariableReferenceExpression outVar = new CodeVariableReferenceExpression("retVal");
+                    CodeExpression resultExpression = invokeMethod;
+                    if (isTask)
+                    {
+                        resultExpression = new CodeAwaitExpression(
+                            new CodeMethodInvokeExpression(
+                                new CodeMethodReferenceExpression(invokeMethod, "ConfigureAwait"),
+                                new CodePrimitiveExpression(false)));
+                    }
 
-                    helperMethod.Statements.Add(new CodeVariableDeclarationStatement(method.ReturnType, outVar.VariableName, invokeMethod));
+                    helperMethod.Statements.Add(new CodeVariableDeclarationStatement(resultType, outVar.VariableName, resultExpression));
                     CodeMethodReturnStatement returnStatement = GenerateParameters(helperMethod, returnTypeDecl, outVar, FieldDirection.Out);
                     if (returnStatement != null)
                         helperMethod.Statements.Add(returnStatement);
+
+                    if (isTask)
+                    {
+                        helperMethod.UserData[CodeAwaitExpression.AsyncMethodUserDataKey] = true;
+                        helperMethod.ReturnType = helperMethod.ReturnType.BaseType == s_voidTypeRef.BaseType
+                            ? new CodeTypeReference(typeof(Task))
+                            : new CodeTypeReference(typeof(Task<>).FullName, helperMethod.ReturnType);
+                    }
                 }
                 else
                 {
@@ -307,6 +330,44 @@ namespace System.ServiceModel.Description
             if (hasTypedMessage)
                 method.PrivateImplementationType = ifaceType;
             return hasTypedMessage ? helperMethod : null;
+        }
+
+        private static bool CanUnwrapTaskResult(CodeTypeDeclaration codeTypeDeclaration, CodeParameterDeclarationExpressionCollection inputParameters)
+        {
+            if (codeTypeDeclaration == null)
+                return false;
+
+            int outputValueCount = 0;
+            bool conflictsWithInput = false;
+            CountOutputValues(codeTypeDeclaration, inputParameters, ref outputValueCount, ref conflictsWithInput);
+            return outputValueCount <= 1 && !conflictsWithInput;
+        }
+
+        private static void CountOutputValues(CodeTypeDeclaration codeTypeDeclaration, CodeParameterDeclarationExpressionCollection inputParameters, ref int outputValueCount, ref bool conflictsWithInput)
+        {
+            foreach (CodeTypeMember member in codeTypeDeclaration.Members)
+            {
+                CodeMemberField field = member as CodeMemberField;
+                if (field == null)
+                    continue;
+
+                CodeTypeDeclaration nestedType = ServiceContractGenerator.NamespaceHelper.GetCodeType(field.Type);
+                if (nestedType != null)
+                {
+                    CountOutputValues(nestedType, inputParameters, ref outputValueCount, ref conflictsWithInput);
+                    continue;
+                }
+
+                outputValueCount++;
+                foreach (CodeParameterDeclarationExpression inputParameter in inputParameters)
+                {
+                    if (inputParameter.Name == field.Name && inputParameter.Type.BaseType == field.Type.BaseType)
+                    {
+                        conflictsWithInput = true;
+                        break;
+                    }
+                }
+            }
         }
 
         private static CodeMethodReturnStatement GenerateParameters(CodeMemberMethod helperMethod, CodeTypeDeclaration codeTypeDeclaration, CodeExpression target, FieldDirection dir)

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/XmlSerializer/Reference.cs
@@ -1835,11 +1835,12 @@ namespace XmlSerializer_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message)
         {
             XmlSerializer_NS.EchoWithTimeoutRequest inValue = new XmlSerializer_NS.EchoWithTimeoutRequest();
             inValue.message = message;
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).EchoWithTimeoutAsync(inValue);
+            XmlSerializer_NS.EchoWithTimeoutResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -1853,11 +1854,12 @@ namespace XmlSerializer_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             XmlSerializer_NS.EchoRequest inValue = new XmlSerializer_NS.EchoRequest();
             inValue.message = message;
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).EchoAsync(inValue);
+            XmlSerializer_NS.EchoResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -1866,11 +1868,12 @@ namespace XmlSerializer_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.EchoComplexResponse> EchoComplexAsync(XmlSerializer_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<XmlSerializer_NS.ComplexCompositeType> EchoComplexAsync(XmlSerializer_NS.ComplexCompositeType message)
         {
             XmlSerializer_NS.EchoComplexRequest inValue = new XmlSerializer_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).EchoComplexAsync(inValue);
+            XmlSerializer_NS.EchoComplexResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -1879,11 +1882,11 @@ namespace XmlSerializer_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             XmlSerializer_NS.TestFaultRequest inValue = new XmlSerializer_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).TestFaultAsync(inValue);
+            XmlSerializer_NS.TestFaultResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -1892,11 +1895,11 @@ namespace XmlSerializer_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             XmlSerializer_NS.ThrowInvalidOperationExceptionRequest inValue = new XmlSerializer_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            XmlSerializer_NS.ThrowInvalidOperationExceptionResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -1905,11 +1908,12 @@ namespace XmlSerializer_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(XmlSerializer_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<XmlSerializer_NS.CompositeType> GetDataUsingDataContractAsync(XmlSerializer_NS.CompositeType composite)
         {
             XmlSerializer_NS.GetDataUsingDataContractRequest inValue = new XmlSerializer_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).GetDataUsingDataContractAsync(inValue);
+            XmlSerializer_NS.GetDataUsingDataContractResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -1918,10 +1922,11 @@ namespace XmlSerializer_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<XmlSerializer_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             XmlSerializer_NS.ValidateMessagePropertyHeadersRequest inValue = new XmlSerializer_NS.ValidateMessagePropertyHeadersRequest();
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            XmlSerializer_NS.ValidateMessagePropertyHeadersResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -1930,11 +1935,12 @@ namespace XmlSerializer_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync(string liveId)
+        public async System.Threading.Tasks.Task<XmlSerializer_NS.ResultOfstring> UserGetAuthTokenAsync(string liveId)
         {
             XmlSerializer_NS.UserGetAuthTokenRequest inValue = new XmlSerializer_NS.UserGetAuthTokenRequest();
             inValue.liveId = liveId;
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).UserGetAuthTokenAsync(inValue);
+            XmlSerializer_NS.UserGetAuthTokenResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -1943,12 +1949,13 @@ namespace XmlSerializer_NS
             return base.Channel.UserGamePlayGetListAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.UserGamePlayGetListResponse> UserGamePlayGetListAsync(string gameKey, string keys)
+        public async System.Threading.Tasks.Task<XmlSerializer_NS.ResultOfArrayOfUserGamePlay> UserGamePlayGetListAsync(string gameKey, string keys)
         {
             XmlSerializer_NS.UserGamePlayGetListRequest inValue = new XmlSerializer_NS.UserGamePlayGetListRequest();
             inValue.gameKey = gameKey;
             inValue.keys = keys;
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).UserGamePlayGetListAsync(inValue);
+            XmlSerializer_NS.UserGamePlayGetListResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).UserGamePlayGetListAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGamePlayGetListResult;
         }
         
         public System.Threading.Tasks.Task<XmlSerializer_NS.ReplyBankingData> MessageContractRequestReplyAsync(XmlSerializer_NS.RequestBankingData request)
@@ -1967,10 +1974,11 @@ namespace XmlSerializer_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<XmlSerializer_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<XmlSerializer_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             XmlSerializer_NS.EchoHttpRequestMessagePropertyRequest inValue = new XmlSerializer_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((XmlSerializer_NS.IWcfProjectNService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            XmlSerializer_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((XmlSerializer_NS.IWcfProjectNService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/CodeGenOptions/wrapped/Reference.cs
@@ -2365,11 +2365,12 @@ namespace wrapped_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.EchoWithTimeoutResponse1> EchoWithTimeoutAsync(wrapped_NS.EchoWithTimeout EchoWithTimeout)
+        public async System.Threading.Tasks.Task<wrapped_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(wrapped_NS.EchoWithTimeout EchoWithTimeout)
         {
             wrapped_NS.EchoWithTimeoutRequest inValue = new wrapped_NS.EchoWithTimeoutRequest();
             inValue.EchoWithTimeout = EchoWithTimeout;
-            return ((wrapped_NS.IWcfProjectNService)(this)).EchoWithTimeoutAsync(inValue);
+            wrapped_NS.EchoWithTimeoutResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResponse;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2383,11 +2384,12 @@ namespace wrapped_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.EchoResponse1> EchoAsync(wrapped_NS.Echo Echo)
+        public async System.Threading.Tasks.Task<wrapped_NS.EchoResponse> EchoAsync(wrapped_NS.Echo Echo)
         {
             wrapped_NS.EchoRequest inValue = new wrapped_NS.EchoRequest();
             inValue.Echo = Echo;
-            return ((wrapped_NS.IWcfProjectNService)(this)).EchoAsync(inValue);
+            wrapped_NS.EchoResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResponse;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2396,11 +2398,12 @@ namespace wrapped_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.EchoComplexResponse1> EchoComplexAsync(wrapped_NS.EchoComplex EchoComplex)
+        public async System.Threading.Tasks.Task<wrapped_NS.EchoComplexResponse> EchoComplexAsync(wrapped_NS.EchoComplex EchoComplex)
         {
             wrapped_NS.EchoComplexRequest inValue = new wrapped_NS.EchoComplexRequest();
             inValue.EchoComplex = EchoComplex;
-            return ((wrapped_NS.IWcfProjectNService)(this)).EchoComplexAsync(inValue);
+            wrapped_NS.EchoComplexResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResponse;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2409,11 +2412,12 @@ namespace wrapped_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.TestFaultResponse1> TestFaultAsync(wrapped_NS.TestFault TestFault)
+        public async System.Threading.Tasks.Task<wrapped_NS.TestFaultResponse> TestFaultAsync(wrapped_NS.TestFault TestFault)
         {
             wrapped_NS.TestFaultRequest inValue = new wrapped_NS.TestFaultRequest();
             inValue.TestFault = TestFault;
-            return ((wrapped_NS.IWcfProjectNService)(this)).TestFaultAsync(inValue);
+            wrapped_NS.TestFaultResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultResponse;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2422,11 +2426,12 @@ namespace wrapped_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.ThrowInvalidOperationExceptionResponse1> ThrowInvalidOperationExceptionAsync(wrapped_NS.ThrowInvalidOperationException ThrowInvalidOperationException)
+        public async System.Threading.Tasks.Task<wrapped_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(wrapped_NS.ThrowInvalidOperationException ThrowInvalidOperationException)
         {
             wrapped_NS.ThrowInvalidOperationExceptionRequest inValue = new wrapped_NS.ThrowInvalidOperationExceptionRequest();
             inValue.ThrowInvalidOperationException = ThrowInvalidOperationException;
-            return ((wrapped_NS.IWcfProjectNService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            wrapped_NS.ThrowInvalidOperationExceptionResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
+            return retVal.ThrowInvalidOperationExceptionResponse;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2435,11 +2440,12 @@ namespace wrapped_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.GetDataUsingDataContractResponse1> GetDataUsingDataContractAsync(wrapped_NS.GetDataUsingDataContract GetDataUsingDataContract)
+        public async System.Threading.Tasks.Task<wrapped_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(wrapped_NS.GetDataUsingDataContract GetDataUsingDataContract)
         {
             wrapped_NS.GetDataUsingDataContractRequest inValue = new wrapped_NS.GetDataUsingDataContractRequest();
             inValue.GetDataUsingDataContract = GetDataUsingDataContract;
-            return ((wrapped_NS.IWcfProjectNService)(this)).GetDataUsingDataContractAsync(inValue);
+            wrapped_NS.GetDataUsingDataContractResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResponse;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2448,11 +2454,12 @@ namespace wrapped_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.ValidateMessagePropertyHeadersResponse1> ValidateMessagePropertyHeadersAsync(wrapped_NS.ValidateMessagePropertyHeaders ValidateMessagePropertyHeaders)
+        public async System.Threading.Tasks.Task<wrapped_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync(wrapped_NS.ValidateMessagePropertyHeaders ValidateMessagePropertyHeaders)
         {
             wrapped_NS.ValidateMessagePropertyHeadersRequest inValue = new wrapped_NS.ValidateMessagePropertyHeadersRequest();
             inValue.ValidateMessagePropertyHeaders = ValidateMessagePropertyHeaders;
-            return ((wrapped_NS.IWcfProjectNService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            wrapped_NS.ValidateMessagePropertyHeadersResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResponse;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2461,11 +2468,12 @@ namespace wrapped_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.UserGetAuthTokenResponse1> UserGetAuthTokenAsync(wrapped_NS.UserGetAuthToken UserGetAuthToken)
+        public async System.Threading.Tasks.Task<wrapped_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync(wrapped_NS.UserGetAuthToken UserGetAuthToken)
         {
             wrapped_NS.UserGetAuthTokenRequest inValue = new wrapped_NS.UserGetAuthTokenRequest();
             inValue.UserGetAuthToken = UserGetAuthToken;
-            return ((wrapped_NS.IWcfProjectNService)(this)).UserGetAuthTokenAsync(inValue);
+            wrapped_NS.UserGetAuthTokenResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResponse;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2474,11 +2482,12 @@ namespace wrapped_NS
             return base.Channel.UserGamePlayGetListAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.UserGamePlayGetListResponse1> UserGamePlayGetListAsync(wrapped_NS.UserGamePlayGetList UserGamePlayGetList)
+        public async System.Threading.Tasks.Task<wrapped_NS.UserGamePlayGetListResponse> UserGamePlayGetListAsync(wrapped_NS.UserGamePlayGetList UserGamePlayGetList)
         {
             wrapped_NS.UserGamePlayGetListRequest inValue = new wrapped_NS.UserGamePlayGetListRequest();
             inValue.UserGamePlayGetList = UserGamePlayGetList;
-            return ((wrapped_NS.IWcfProjectNService)(this)).UserGamePlayGetListAsync(inValue);
+            wrapped_NS.UserGamePlayGetListResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).UserGamePlayGetListAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGamePlayGetListResponse;
         }
         
         public System.Threading.Tasks.Task<wrapped_NS.ReplyBankingData> MessageContractRequestReplyAsync(wrapped_NS.RequestBankingData request)
@@ -2497,11 +2506,12 @@ namespace wrapped_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<wrapped_NS.EchoHttpRequestMessagePropertyResponse1> EchoHttpRequestMessagePropertyAsync(wrapped_NS.EchoHttpRequestMessageProperty EchoHttpRequestMessageProperty)
+        public async System.Threading.Tasks.Task<wrapped_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync(wrapped_NS.EchoHttpRequestMessageProperty EchoHttpRequestMessageProperty)
         {
             wrapped_NS.EchoHttpRequestMessagePropertyRequest inValue = new wrapped_NS.EchoHttpRequestMessagePropertyRequest();
             inValue.EchoHttpRequestMessageProperty = EchoHttpRequestMessageProperty;
-            return ((wrapped_NS.IWcfProjectNService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            wrapped_NS.EchoHttpRequestMessagePropertyResponse1 retVal = await ((wrapped_NS.IWcfProjectNService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResponse;
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/FederationServiceTest/Saml2IssuedToken_mex/Reference.cs
@@ -2355,12 +2355,13 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             Saml2IssuedToken_mex_NS.EchoWithTimeoutRequest inValue = new Saml2IssuedToken_mex_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            Saml2IssuedToken_mex_NS.EchoWithTimeoutResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2374,11 +2375,12 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             Saml2IssuedToken_mex_NS.EchoRequest inValue = new Saml2IssuedToken_mex_NS.EchoRequest();
             inValue.message = message;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoAsync(inValue);
+            Saml2IssuedToken_mex_NS.EchoResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2387,11 +2389,12 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.EchoComplexResponse> EchoComplexAsync(Saml2IssuedToken_mex_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.ComplexCompositeType> EchoComplexAsync(Saml2IssuedToken_mex_NS.ComplexCompositeType message)
         {
             Saml2IssuedToken_mex_NS.EchoComplexRequest inValue = new Saml2IssuedToken_mex_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            Saml2IssuedToken_mex_NS.EchoComplexResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2400,11 +2403,11 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             Saml2IssuedToken_mex_NS.TestFaultRequest inValue = new Saml2IssuedToken_mex_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            Saml2IssuedToken_mex_NS.TestFaultResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2418,12 +2421,12 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             Saml2IssuedToken_mex_NS.TestFaultsRequest inValue = new Saml2IssuedToken_mex_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            Saml2IssuedToken_mex_NS.TestFaultsResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2432,12 +2435,13 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             Saml2IssuedToken_mex_NS.TestFaultWithKnownTypeRequest inValue = new Saml2IssuedToken_mex_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            Saml2IssuedToken_mex_NS.TestFaultWithKnownTypeResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2446,11 +2450,11 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             Saml2IssuedToken_mex_NS.ThrowInvalidOperationExceptionRequest inValue = new Saml2IssuedToken_mex_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            Saml2IssuedToken_mex_NS.ThrowInvalidOperationExceptionResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2459,11 +2463,12 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(Saml2IssuedToken_mex_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.CompositeType> GetDataUsingDataContractAsync(Saml2IssuedToken_mex_NS.CompositeType composite)
         {
             Saml2IssuedToken_mex_NS.GetDataUsingDataContractRequest inValue = new Saml2IssuedToken_mex_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            Saml2IssuedToken_mex_NS.GetDataUsingDataContractResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2472,10 +2477,11 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             Saml2IssuedToken_mex_NS.ValidateMessagePropertyHeadersRequest inValue = new Saml2IssuedToken_mex_NS.ValidateMessagePropertyHeadersRequest();
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            Saml2IssuedToken_mex_NS.ValidateMessagePropertyHeadersResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2484,10 +2490,11 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             Saml2IssuedToken_mex_NS.UserGetAuthTokenRequest inValue = new Saml2IssuedToken_mex_NS.UserGetAuthTokenRequest();
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            Saml2IssuedToken_mex_NS.UserGetAuthTokenResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.ReplyBankingData> MessageContractRequestReplyAsync(Saml2IssuedToken_mex_NS.RequestBankingData request)
@@ -2516,10 +2523,11 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             Saml2IssuedToken_mex_NS.EchoHttpRequestMessagePropertyRequest inValue = new Saml2IssuedToken_mex_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            Saml2IssuedToken_mex_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2528,10 +2536,11 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             Saml2IssuedToken_mex_NS.GetRestartServiceEndpointRequest inValue = new Saml2IssuedToken_mex_NS.GetRestartServiceEndpointRequest();
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            Saml2IssuedToken_mex_NS.GetRestartServiceEndpointResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2560,13 +2569,14 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             Saml2IssuedToken_mex_NS.LoginRequest inValue = new Saml2IssuedToken_mex_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).LoginAsync(inValue);
+            Saml2IssuedToken_mex_NS.LoginResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2580,11 +2590,12 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             Saml2IssuedToken_mex_NS.GetStreamFromStringRequest inValue = new Saml2IssuedToken_mex_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            Saml2IssuedToken_mex_NS.GetStreamFromStringResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2593,11 +2604,12 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             Saml2IssuedToken_mex_NS.GetStringFromStreamRequest inValue = new Saml2IssuedToken_mex_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            Saml2IssuedToken_mex_NS.GetStringFromStreamResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2611,11 +2623,12 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             Saml2IssuedToken_mex_NS.EchoMessageParameterRequest inValue = new Saml2IssuedToken_mex_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            Saml2IssuedToken_mex_NS.EchoMessageParameterResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2624,11 +2637,12 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             Saml2IssuedToken_mex_NS.EchoItemsRequest inValue = new Saml2IssuedToken_mex_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            Saml2IssuedToken_mex_NS.EchoItemsResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2652,11 +2666,11 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             Saml2IssuedToken_mex_NS.ReturnContentTypeRequest inValue = new Saml2IssuedToken_mex_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            Saml2IssuedToken_mex_NS.ReturnContentTypeResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2696,10 +2710,11 @@ namespace Saml2IssuedToken_mex_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<Saml2IssuedToken_mex_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             Saml2IssuedToken_mex_NS.GetRequestHttpHeadersRequest inValue = new Saml2IssuedToken_mex_NS.GetRequestHttpHeadersRequest();
-            return ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            Saml2IssuedToken_mex_NS.GetRequestHttpHeadersResponse retVal = await ((Saml2IssuedToken_mex_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/MessageContractMemberNamedSystem/MessageContractMemberNamedSystem/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MessageContractMemberNamedSystem/MessageContractMemberNamedSystem/Reference.cs
@@ -172,11 +172,12 @@ namespace MessageContractMemberNamedSystem_NS
             return base.Channel.ProcessAsync(request);
         }
         
-        public System.Threading.Tasks.Task<MessageContractMemberNamedSystem_NS.Response> ProcessAsync(MessageContractMemberNamedSystem_NS.Component SystemMember)
+        public async System.Threading.Tasks.Task<string> ProcessAsync(MessageContractMemberNamedSystem_NS.Component SystemMember)
         {
             MessageContractMemberNamedSystem_NS.Request inValue = new MessageContractMemberNamedSystem_NS.Request();
             inValue.SystemMember = SystemMember;
-            return ((MessageContractMemberNamedSystem_NS.IMyService)(this)).ProcessAsync(inValue);
+            MessageContractMemberNamedSystem_NS.Response retVal = await ((MessageContractMemberNamedSystem_NS.IMyService)(this)).ProcessAsync(inValue).ConfigureAwait(false);
+            return retVal.Result;
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicHttpsTransSecMessCredsUserName/BasicHttpsTransSecMessCredsUserName/Reference.cs
@@ -2355,12 +2355,13 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             BasicHttpsTransSecMessCredsUserName_NS.EchoWithTimeoutRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.EchoWithTimeoutResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2374,11 +2375,12 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             BasicHttpsTransSecMessCredsUserName_NS.EchoRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.EchoRequest();
             inValue.message = message;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.EchoResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2387,11 +2389,12 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.EchoComplexResponse> EchoComplexAsync(BasicHttpsTransSecMessCredsUserName_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.ComplexCompositeType> EchoComplexAsync(BasicHttpsTransSecMessCredsUserName_NS.ComplexCompositeType message)
         {
             BasicHttpsTransSecMessCredsUserName_NS.EchoComplexRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.EchoComplexResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2400,11 +2403,11 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             BasicHttpsTransSecMessCredsUserName_NS.TestFaultRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.TestFaultResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2418,12 +2421,12 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             BasicHttpsTransSecMessCredsUserName_NS.TestFaultsRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.TestFaultsResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2432,12 +2435,13 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             BasicHttpsTransSecMessCredsUserName_NS.TestFaultWithKnownTypeRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.TestFaultWithKnownTypeResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2446,11 +2450,11 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             BasicHttpsTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2459,11 +2463,12 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(BasicHttpsTransSecMessCredsUserName_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.CompositeType> GetDataUsingDataContractAsync(BasicHttpsTransSecMessCredsUserName_NS.CompositeType composite)
         {
             BasicHttpsTransSecMessCredsUserName_NS.GetDataUsingDataContractRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.GetDataUsingDataContractResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2472,10 +2477,11 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             BasicHttpsTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersRequest();
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2484,10 +2490,11 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             BasicHttpsTransSecMessCredsUserName_NS.UserGetAuthTokenRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.UserGetAuthTokenRequest();
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.UserGetAuthTokenResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.ReplyBankingData> MessageContractRequestReplyAsync(BasicHttpsTransSecMessCredsUserName_NS.RequestBankingData request)
@@ -2516,10 +2523,11 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             BasicHttpsTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2528,10 +2536,11 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             BasicHttpsTransSecMessCredsUserName_NS.GetRestartServiceEndpointRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.GetRestartServiceEndpointRequest();
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.GetRestartServiceEndpointResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2560,13 +2569,14 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             BasicHttpsTransSecMessCredsUserName_NS.LoginRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).LoginAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.LoginResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2580,11 +2590,12 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             BasicHttpsTransSecMessCredsUserName_NS.GetStreamFromStringRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.GetStreamFromStringResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2593,11 +2604,12 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             BasicHttpsTransSecMessCredsUserName_NS.GetStringFromStreamRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.GetStringFromStreamResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2611,11 +2623,12 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             BasicHttpsTransSecMessCredsUserName_NS.EchoMessageParameterRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.EchoMessageParameterResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2624,11 +2637,12 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             BasicHttpsTransSecMessCredsUserName_NS.EchoItemsRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.EchoItemsResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2652,11 +2666,11 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             BasicHttpsTransSecMessCredsUserName_NS.ReturnContentTypeRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.ReturnContentTypeResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2696,10 +2710,11 @@ namespace BasicHttpsTransSecMessCredsUserName_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<BasicHttpsTransSecMessCredsUserName_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest inValue = new BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest();
-            return ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            BasicHttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse retVal = await ((BasicHttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp/Reference.cs
@@ -2355,12 +2355,13 @@ namespace BasicHttp_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             BasicHttp_NS.EchoWithTimeoutRequest inValue = new BasicHttp_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((BasicHttp_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            BasicHttp_NS.EchoWithTimeoutResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2374,11 +2375,12 @@ namespace BasicHttp_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             BasicHttp_NS.EchoRequest inValue = new BasicHttp_NS.EchoRequest();
             inValue.message = message;
-            return ((BasicHttp_NS.IWcfService)(this)).EchoAsync(inValue);
+            BasicHttp_NS.EchoResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2387,11 +2389,12 @@ namespace BasicHttp_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.EchoComplexResponse> EchoComplexAsync(BasicHttp_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<BasicHttp_NS.ComplexCompositeType> EchoComplexAsync(BasicHttp_NS.ComplexCompositeType message)
         {
             BasicHttp_NS.EchoComplexRequest inValue = new BasicHttp_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((BasicHttp_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            BasicHttp_NS.EchoComplexResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2400,11 +2403,11 @@ namespace BasicHttp_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             BasicHttp_NS.TestFaultRequest inValue = new BasicHttp_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((BasicHttp_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            BasicHttp_NS.TestFaultResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2418,12 +2421,12 @@ namespace BasicHttp_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             BasicHttp_NS.TestFaultsRequest inValue = new BasicHttp_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((BasicHttp_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            BasicHttp_NS.TestFaultsResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2432,12 +2435,13 @@ namespace BasicHttp_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             BasicHttp_NS.TestFaultWithKnownTypeRequest inValue = new BasicHttp_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((BasicHttp_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            BasicHttp_NS.TestFaultWithKnownTypeResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2446,11 +2450,11 @@ namespace BasicHttp_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             BasicHttp_NS.ThrowInvalidOperationExceptionRequest inValue = new BasicHttp_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((BasicHttp_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            BasicHttp_NS.ThrowInvalidOperationExceptionResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2459,11 +2463,12 @@ namespace BasicHttp_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(BasicHttp_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<BasicHttp_NS.CompositeType> GetDataUsingDataContractAsync(BasicHttp_NS.CompositeType composite)
         {
             BasicHttp_NS.GetDataUsingDataContractRequest inValue = new BasicHttp_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((BasicHttp_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            BasicHttp_NS.GetDataUsingDataContractResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2472,10 +2477,11 @@ namespace BasicHttp_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<BasicHttp_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             BasicHttp_NS.ValidateMessagePropertyHeadersRequest inValue = new BasicHttp_NS.ValidateMessagePropertyHeadersRequest();
-            return ((BasicHttp_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            BasicHttp_NS.ValidateMessagePropertyHeadersResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2484,10 +2490,11 @@ namespace BasicHttp_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<BasicHttp_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             BasicHttp_NS.UserGetAuthTokenRequest inValue = new BasicHttp_NS.UserGetAuthTokenRequest();
-            return ((BasicHttp_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            BasicHttp_NS.UserGetAuthTokenResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<BasicHttp_NS.ReplyBankingData> MessageContractRequestReplyAsync(BasicHttp_NS.RequestBankingData request)
@@ -2516,10 +2523,11 @@ namespace BasicHttp_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<BasicHttp_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             BasicHttp_NS.EchoHttpRequestMessagePropertyRequest inValue = new BasicHttp_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((BasicHttp_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            BasicHttp_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2528,10 +2536,11 @@ namespace BasicHttp_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             BasicHttp_NS.GetRestartServiceEndpointRequest inValue = new BasicHttp_NS.GetRestartServiceEndpointRequest();
-            return ((BasicHttp_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            BasicHttp_NS.GetRestartServiceEndpointResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2560,13 +2569,14 @@ namespace BasicHttp_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             BasicHttp_NS.LoginRequest inValue = new BasicHttp_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((BasicHttp_NS.IWcfService)(this)).LoginAsync(inValue);
+            BasicHttp_NS.LoginResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2580,11 +2590,12 @@ namespace BasicHttp_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             BasicHttp_NS.GetStreamFromStringRequest inValue = new BasicHttp_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((BasicHttp_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            BasicHttp_NS.GetStreamFromStringResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2593,11 +2604,12 @@ namespace BasicHttp_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             BasicHttp_NS.GetStringFromStreamRequest inValue = new BasicHttp_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((BasicHttp_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            BasicHttp_NS.GetStringFromStreamResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2611,11 +2623,12 @@ namespace BasicHttp_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             BasicHttp_NS.EchoMessageParameterRequest inValue = new BasicHttp_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((BasicHttp_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            BasicHttp_NS.EchoMessageParameterResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2624,11 +2637,12 @@ namespace BasicHttp_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             BasicHttp_NS.EchoItemsRequest inValue = new BasicHttp_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((BasicHttp_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            BasicHttp_NS.EchoItemsResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2652,11 +2666,11 @@ namespace BasicHttp_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             BasicHttp_NS.ReturnContentTypeRequest inValue = new BasicHttp_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((BasicHttp_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            BasicHttp_NS.ReturnContentTypeResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2696,10 +2710,11 @@ namespace BasicHttp_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<BasicHttp_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             BasicHttp_NS.GetRequestHttpHeadersRequest inValue = new BasicHttp_NS.GetRequestHttpHeadersRequest();
-            return ((BasicHttp_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            BasicHttp_NS.GetRequestHttpHeadersResponse retVal = await ((BasicHttp_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitDualNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitDualNs/Reference.cs
@@ -760,12 +760,13 @@ namespace BasicHttpDocLitDualNs_NS
             return base.Channel.SumAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitDualNs_NS.SumResponse> SumAsync(BasicHttpDocLitDualNs_NS.IntParams par)
+        public async System.Threading.Tasks.Task<int> SumAsync(BasicHttpDocLitDualNs_NS.IntParams par)
         {
             BasicHttpDocLitDualNs_NS.SumRequest inValue = new BasicHttpDocLitDualNs_NS.SumRequest();
             inValue.Body = new BasicHttpDocLitDualNs_NS.SumRequestBody();
             inValue.Body.par = par;
-            return ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).SumAsync(inValue);
+            BasicHttpDocLitDualNs_NS.SumResponse retVal = await ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).SumAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.SumResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -774,12 +775,13 @@ namespace BasicHttpDocLitDualNs_NS
             return base.Channel.DivideAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitDualNs_NS.DivideResponse> DivideAsync(BasicHttpDocLitDualNs_NS.FloatParams par)
+        public async System.Threading.Tasks.Task<float> DivideAsync(BasicHttpDocLitDualNs_NS.FloatParams par)
         {
             BasicHttpDocLitDualNs_NS.DivideRequest inValue = new BasicHttpDocLitDualNs_NS.DivideRequest();
             inValue.Body = new BasicHttpDocLitDualNs_NS.DivideRequestBody();
             inValue.Body.par = par;
-            return ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).DivideAsync(inValue);
+            BasicHttpDocLitDualNs_NS.DivideResponse retVal = await ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).DivideAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.DivideResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -788,12 +790,13 @@ namespace BasicHttpDocLitDualNs_NS
             return base.Channel.ConcatenateAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitDualNs_NS.ConcatenateResponse> ConcatenateAsync(BasicHttpDocLitDualNs_NS.IntParams par)
+        public async System.Threading.Tasks.Task<string> ConcatenateAsync(BasicHttpDocLitDualNs_NS.IntParams par)
         {
             BasicHttpDocLitDualNs_NS.ConcatenateRequest inValue = new BasicHttpDocLitDualNs_NS.ConcatenateRequest();
             inValue.Body = new BasicHttpDocLitDualNs_NS.ConcatenateRequestBody();
             inValue.Body.par = par;
-            return ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).ConcatenateAsync(inValue);
+            BasicHttpDocLitDualNs_NS.ConcatenateResponse retVal = await ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).ConcatenateAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.ConcatenateResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -802,13 +805,13 @@ namespace BasicHttpDocLitDualNs_NS
             return base.Channel.AddIntParamsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitDualNs_NS.AddIntParamsResponse> AddIntParamsAsync(string guid, BasicHttpDocLitDualNs_NS.IntParams par)
+        public async System.Threading.Tasks.Task AddIntParamsAsync(string guid, BasicHttpDocLitDualNs_NS.IntParams par)
         {
             BasicHttpDocLitDualNs_NS.AddIntParamsRequest inValue = new BasicHttpDocLitDualNs_NS.AddIntParamsRequest();
             inValue.Body = new BasicHttpDocLitDualNs_NS.AddIntParamsRequestBody();
             inValue.Body.guid = guid;
             inValue.Body.par = par;
-            return ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).AddIntParamsAsync(inValue);
+            BasicHttpDocLitDualNs_NS.AddIntParamsResponse retVal = await ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).AddIntParamsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -817,12 +820,13 @@ namespace BasicHttpDocLitDualNs_NS
             return base.Channel.GetAndRemoveIntParamsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitDualNs_NS.GetAndRemoveIntParamsResponse> GetAndRemoveIntParamsAsync(string guid)
+        public async System.Threading.Tasks.Task<BasicHttpDocLitDualNs_NS.IntParams> GetAndRemoveIntParamsAsync(string guid)
         {
             BasicHttpDocLitDualNs_NS.GetAndRemoveIntParamsRequest inValue = new BasicHttpDocLitDualNs_NS.GetAndRemoveIntParamsRequest();
             inValue.Body = new BasicHttpDocLitDualNs_NS.GetAndRemoveIntParamsRequestBody();
             inValue.Body.guid = guid;
-            return ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).GetAndRemoveIntParamsAsync(inValue);
+            BasicHttpDocLitDualNs_NS.GetAndRemoveIntParamsResponse retVal = await ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).GetAndRemoveIntParamsAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.GetAndRemoveIntParamsResult;
         }
         
         public System.Threading.Tasks.Task<System.DateTime> ReturnInputDateTimeAsync(System.DateTime dt)
@@ -836,12 +840,13 @@ namespace BasicHttpDocLitDualNs_NS
             return base.Channel.CreateSetAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitDualNs_NS.CreateSetResponse> CreateSetAsync(BasicHttpDocLitDualNs_NS.ByteParams par)
+        public async System.Threading.Tasks.Task<byte[]> CreateSetAsync(BasicHttpDocLitDualNs_NS.ByteParams par)
         {
             BasicHttpDocLitDualNs_NS.CreateSetRequest inValue = new BasicHttpDocLitDualNs_NS.CreateSetRequest();
             inValue.Body = new BasicHttpDocLitDualNs_NS.CreateSetRequestBody();
             inValue.Body.par = par;
-            return ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).CreateSetAsync(inValue);
+            BasicHttpDocLitDualNs_NS.CreateSetResponse retVal = await ((BasicHttpDocLitDualNs_NS.ICalculatorDocLit)(this)).CreateSetAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.CreateSetResult;
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()
@@ -1130,13 +1135,13 @@ namespace BasicHttpDocLitDualNs_NS
             return base.Channel.AddStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitDualNs_NS.AddStringResponse> AddStringAsync(string guid, string testString)
+        public async System.Threading.Tasks.Task AddStringAsync(string guid, string testString)
         {
             BasicHttpDocLitDualNs_NS.AddStringRequest inValue = new BasicHttpDocLitDualNs_NS.AddStringRequest();
             inValue.Body = new BasicHttpDocLitDualNs_NS.AddStringRequestBody();
             inValue.Body.guid = guid;
             inValue.Body.testString = testString;
-            return ((BasicHttpDocLitDualNs_NS.IHelloWorldDocLit)(this)).AddStringAsync(inValue);
+            BasicHttpDocLitDualNs_NS.AddStringResponse retVal = await ((BasicHttpDocLitDualNs_NS.IHelloWorldDocLit)(this)).AddStringAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -1145,12 +1150,13 @@ namespace BasicHttpDocLitDualNs_NS
             return base.Channel.GetAndRemoveStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitDualNs_NS.GetAndRemoveStringResponse> GetAndRemoveStringAsync(string guid)
+        public async System.Threading.Tasks.Task<string> GetAndRemoveStringAsync(string guid)
         {
             BasicHttpDocLitDualNs_NS.GetAndRemoveStringRequest inValue = new BasicHttpDocLitDualNs_NS.GetAndRemoveStringRequest();
             inValue.Body = new BasicHttpDocLitDualNs_NS.GetAndRemoveStringRequestBody();
             inValue.Body.guid = guid;
-            return ((BasicHttpDocLitDualNs_NS.IHelloWorldDocLit)(this)).GetAndRemoveStringAsync(inValue);
+            BasicHttpDocLitDualNs_NS.GetAndRemoveStringResponse retVal = await ((BasicHttpDocLitDualNs_NS.IHelloWorldDocLit)(this)).GetAndRemoveStringAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.GetAndRemoveStringResult;
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitSingleNs/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttpDocLitSingleNs/Reference.cs
@@ -760,12 +760,13 @@ namespace BasicHttpDocLitSingleNs_NS
             return base.Channel.SumAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitSingleNs_NS.SumResponse> SumAsync(BasicHttpDocLitSingleNs_NS.IntParams par)
+        public async System.Threading.Tasks.Task<int> SumAsync(BasicHttpDocLitSingleNs_NS.IntParams par)
         {
             BasicHttpDocLitSingleNs_NS.SumRequest inValue = new BasicHttpDocLitSingleNs_NS.SumRequest();
             inValue.Body = new BasicHttpDocLitSingleNs_NS.SumRequestBody();
             inValue.Body.par = par;
-            return ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).SumAsync(inValue);
+            BasicHttpDocLitSingleNs_NS.SumResponse retVal = await ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).SumAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.SumResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -774,12 +775,13 @@ namespace BasicHttpDocLitSingleNs_NS
             return base.Channel.DivideAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitSingleNs_NS.DivideResponse> DivideAsync(BasicHttpDocLitSingleNs_NS.FloatParams par)
+        public async System.Threading.Tasks.Task<float> DivideAsync(BasicHttpDocLitSingleNs_NS.FloatParams par)
         {
             BasicHttpDocLitSingleNs_NS.DivideRequest inValue = new BasicHttpDocLitSingleNs_NS.DivideRequest();
             inValue.Body = new BasicHttpDocLitSingleNs_NS.DivideRequestBody();
             inValue.Body.par = par;
-            return ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).DivideAsync(inValue);
+            BasicHttpDocLitSingleNs_NS.DivideResponse retVal = await ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).DivideAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.DivideResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -788,12 +790,13 @@ namespace BasicHttpDocLitSingleNs_NS
             return base.Channel.ConcatenateAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitSingleNs_NS.ConcatenateResponse> ConcatenateAsync(BasicHttpDocLitSingleNs_NS.IntParams par)
+        public async System.Threading.Tasks.Task<string> ConcatenateAsync(BasicHttpDocLitSingleNs_NS.IntParams par)
         {
             BasicHttpDocLitSingleNs_NS.ConcatenateRequest inValue = new BasicHttpDocLitSingleNs_NS.ConcatenateRequest();
             inValue.Body = new BasicHttpDocLitSingleNs_NS.ConcatenateRequestBody();
             inValue.Body.par = par;
-            return ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).ConcatenateAsync(inValue);
+            BasicHttpDocLitSingleNs_NS.ConcatenateResponse retVal = await ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).ConcatenateAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.ConcatenateResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -802,13 +805,13 @@ namespace BasicHttpDocLitSingleNs_NS
             return base.Channel.AddIntParamsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitSingleNs_NS.AddIntParamsResponse> AddIntParamsAsync(string guid, BasicHttpDocLitSingleNs_NS.IntParams par)
+        public async System.Threading.Tasks.Task AddIntParamsAsync(string guid, BasicHttpDocLitSingleNs_NS.IntParams par)
         {
             BasicHttpDocLitSingleNs_NS.AddIntParamsRequest inValue = new BasicHttpDocLitSingleNs_NS.AddIntParamsRequest();
             inValue.Body = new BasicHttpDocLitSingleNs_NS.AddIntParamsRequestBody();
             inValue.Body.guid = guid;
             inValue.Body.par = par;
-            return ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).AddIntParamsAsync(inValue);
+            BasicHttpDocLitSingleNs_NS.AddIntParamsResponse retVal = await ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).AddIntParamsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -817,12 +820,13 @@ namespace BasicHttpDocLitSingleNs_NS
             return base.Channel.GetAndRemoveIntParamsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitSingleNs_NS.GetAndRemoveIntParamsResponse> GetAndRemoveIntParamsAsync(string guid)
+        public async System.Threading.Tasks.Task<BasicHttpDocLitSingleNs_NS.IntParams> GetAndRemoveIntParamsAsync(string guid)
         {
             BasicHttpDocLitSingleNs_NS.GetAndRemoveIntParamsRequest inValue = new BasicHttpDocLitSingleNs_NS.GetAndRemoveIntParamsRequest();
             inValue.Body = new BasicHttpDocLitSingleNs_NS.GetAndRemoveIntParamsRequestBody();
             inValue.Body.guid = guid;
-            return ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).GetAndRemoveIntParamsAsync(inValue);
+            BasicHttpDocLitSingleNs_NS.GetAndRemoveIntParamsResponse retVal = await ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).GetAndRemoveIntParamsAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.GetAndRemoveIntParamsResult;
         }
         
         public System.Threading.Tasks.Task<System.DateTime> ReturnInputDateTimeAsync(System.DateTime dt)
@@ -836,12 +840,13 @@ namespace BasicHttpDocLitSingleNs_NS
             return base.Channel.CreateSetAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttpDocLitSingleNs_NS.CreateSetResponse> CreateSetAsync(BasicHttpDocLitSingleNs_NS.ByteParams par)
+        public async System.Threading.Tasks.Task<byte[]> CreateSetAsync(BasicHttpDocLitSingleNs_NS.ByteParams par)
         {
             BasicHttpDocLitSingleNs_NS.CreateSetRequest inValue = new BasicHttpDocLitSingleNs_NS.CreateSetRequest();
             inValue.Body = new BasicHttpDocLitSingleNs_NS.CreateSetRequestBody();
             inValue.Body.par = par;
-            return ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).CreateSetAsync(inValue);
+            BasicHttpDocLitSingleNs_NS.CreateSetResponse retVal = await ((BasicHttpDocLitSingleNs_NS.ICalculatorDocLit)(this)).CreateSetAsync(inValue).ConfigureAwait(false);
+            return retVal.Body.CreateSetResult;
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp_4_4_0/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttp_4_4_0/Reference.cs
@@ -250,11 +250,12 @@ namespace BasicHttp_4_4_0_NS
             return base.Channel.SendRequestWithXmlElementMessageHeaderAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttp_4_4_0_NS.XmlElementMessageHeaderResponse> SendRequestWithXmlElementMessageHeaderAsync(BasicHttp_4_4_0_NS.XmlElementMessageHeader TestHeader)
+        public async System.Threading.Tasks.Task<string> SendRequestWithXmlElementMessageHeaderAsync(BasicHttp_4_4_0_NS.XmlElementMessageHeader TestHeader)
         {
             BasicHttp_4_4_0_NS.XmlElementMessageHeaderRequest inValue = new BasicHttp_4_4_0_NS.XmlElementMessageHeaderRequest();
             inValue.TestHeader = TestHeader;
-            return ((BasicHttp_4_4_0_NS.IWcfService_4_4_0)(this)).SendRequestWithXmlElementMessageHeaderAsync(inValue);
+            BasicHttp_4_4_0_NS.XmlElementMessageHeaderResponse retVal = await ((BasicHttp_4_4_0_NS.IWcfService_4_4_0)(this)).SendRequestWithXmlElementMessageHeaderAsync(inValue).ConfigureAwait(false);
+            return retVal.TestResult;
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeBasicSvcs/BasicHttps/Reference.cs
@@ -2355,12 +2355,13 @@ namespace BasicHttps_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             BasicHttps_NS.EchoWithTimeoutRequest inValue = new BasicHttps_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((BasicHttps_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            BasicHttps_NS.EchoWithTimeoutResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2374,11 +2375,12 @@ namespace BasicHttps_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             BasicHttps_NS.EchoRequest inValue = new BasicHttps_NS.EchoRequest();
             inValue.message = message;
-            return ((BasicHttps_NS.IWcfService)(this)).EchoAsync(inValue);
+            BasicHttps_NS.EchoResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2387,11 +2389,12 @@ namespace BasicHttps_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.EchoComplexResponse> EchoComplexAsync(BasicHttps_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<BasicHttps_NS.ComplexCompositeType> EchoComplexAsync(BasicHttps_NS.ComplexCompositeType message)
         {
             BasicHttps_NS.EchoComplexRequest inValue = new BasicHttps_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((BasicHttps_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            BasicHttps_NS.EchoComplexResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2400,11 +2403,11 @@ namespace BasicHttps_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             BasicHttps_NS.TestFaultRequest inValue = new BasicHttps_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((BasicHttps_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            BasicHttps_NS.TestFaultResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2418,12 +2421,12 @@ namespace BasicHttps_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             BasicHttps_NS.TestFaultsRequest inValue = new BasicHttps_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((BasicHttps_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            BasicHttps_NS.TestFaultsResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2432,12 +2435,13 @@ namespace BasicHttps_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             BasicHttps_NS.TestFaultWithKnownTypeRequest inValue = new BasicHttps_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((BasicHttps_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            BasicHttps_NS.TestFaultWithKnownTypeResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2446,11 +2450,11 @@ namespace BasicHttps_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             BasicHttps_NS.ThrowInvalidOperationExceptionRequest inValue = new BasicHttps_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((BasicHttps_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            BasicHttps_NS.ThrowInvalidOperationExceptionResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2459,11 +2463,12 @@ namespace BasicHttps_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(BasicHttps_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<BasicHttps_NS.CompositeType> GetDataUsingDataContractAsync(BasicHttps_NS.CompositeType composite)
         {
             BasicHttps_NS.GetDataUsingDataContractRequest inValue = new BasicHttps_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((BasicHttps_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            BasicHttps_NS.GetDataUsingDataContractResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2472,10 +2477,11 @@ namespace BasicHttps_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<BasicHttps_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             BasicHttps_NS.ValidateMessagePropertyHeadersRequest inValue = new BasicHttps_NS.ValidateMessagePropertyHeadersRequest();
-            return ((BasicHttps_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            BasicHttps_NS.ValidateMessagePropertyHeadersResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2484,10 +2490,11 @@ namespace BasicHttps_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<BasicHttps_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             BasicHttps_NS.UserGetAuthTokenRequest inValue = new BasicHttps_NS.UserGetAuthTokenRequest();
-            return ((BasicHttps_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            BasicHttps_NS.UserGetAuthTokenResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<BasicHttps_NS.ReplyBankingData> MessageContractRequestReplyAsync(BasicHttps_NS.RequestBankingData request)
@@ -2516,10 +2523,11 @@ namespace BasicHttps_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<BasicHttps_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             BasicHttps_NS.EchoHttpRequestMessagePropertyRequest inValue = new BasicHttps_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((BasicHttps_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            BasicHttps_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2528,10 +2536,11 @@ namespace BasicHttps_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             BasicHttps_NS.GetRestartServiceEndpointRequest inValue = new BasicHttps_NS.GetRestartServiceEndpointRequest();
-            return ((BasicHttps_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            BasicHttps_NS.GetRestartServiceEndpointResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2560,13 +2569,14 @@ namespace BasicHttps_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             BasicHttps_NS.LoginRequest inValue = new BasicHttps_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((BasicHttps_NS.IWcfService)(this)).LoginAsync(inValue);
+            BasicHttps_NS.LoginResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2580,11 +2590,12 @@ namespace BasicHttps_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             BasicHttps_NS.GetStreamFromStringRequest inValue = new BasicHttps_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((BasicHttps_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            BasicHttps_NS.GetStreamFromStringResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2593,11 +2604,12 @@ namespace BasicHttps_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             BasicHttps_NS.GetStringFromStreamRequest inValue = new BasicHttps_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((BasicHttps_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            BasicHttps_NS.GetStringFromStreamResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2611,11 +2623,12 @@ namespace BasicHttps_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             BasicHttps_NS.EchoMessageParameterRequest inValue = new BasicHttps_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((BasicHttps_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            BasicHttps_NS.EchoMessageParameterResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2624,11 +2637,12 @@ namespace BasicHttps_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             BasicHttps_NS.EchoItemsRequest inValue = new BasicHttps_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((BasicHttps_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            BasicHttps_NS.EchoItemsResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2652,11 +2666,11 @@ namespace BasicHttps_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             BasicHttps_NS.ReturnContentTypeRequest inValue = new BasicHttps_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((BasicHttps_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            BasicHttps_NS.ReturnContentTypeResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2696,10 +2710,11 @@ namespace BasicHttps_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<BasicHttps_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<BasicHttps_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             BasicHttps_NS.GetRequestHttpHeadersRequest inValue = new BasicHttps_NS.GetRequestHttpHeadersRequest();
-            return ((BasicHttps_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            BasicHttps_NS.GetRequestHttpHeadersResponse retVal = await ((BasicHttps_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttp/Reference.cs
@@ -2355,12 +2355,13 @@ namespace NetHttp_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             NetHttp_NS.EchoWithTimeoutRequest inValue = new NetHttp_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((NetHttp_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            NetHttp_NS.EchoWithTimeoutResponse retVal = await ((NetHttp_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2374,11 +2375,12 @@ namespace NetHttp_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             NetHttp_NS.EchoRequest inValue = new NetHttp_NS.EchoRequest();
             inValue.message = message;
-            return ((NetHttp_NS.IWcfService)(this)).EchoAsync(inValue);
+            NetHttp_NS.EchoResponse retVal = await ((NetHttp_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2387,11 +2389,12 @@ namespace NetHttp_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.EchoComplexResponse> EchoComplexAsync(NetHttp_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<NetHttp_NS.ComplexCompositeType> EchoComplexAsync(NetHttp_NS.ComplexCompositeType message)
         {
             NetHttp_NS.EchoComplexRequest inValue = new NetHttp_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((NetHttp_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            NetHttp_NS.EchoComplexResponse retVal = await ((NetHttp_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2400,11 +2403,11 @@ namespace NetHttp_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             NetHttp_NS.TestFaultRequest inValue = new NetHttp_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((NetHttp_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            NetHttp_NS.TestFaultResponse retVal = await ((NetHttp_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2418,12 +2421,12 @@ namespace NetHttp_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             NetHttp_NS.TestFaultsRequest inValue = new NetHttp_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((NetHttp_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            NetHttp_NS.TestFaultsResponse retVal = await ((NetHttp_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2432,12 +2435,13 @@ namespace NetHttp_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             NetHttp_NS.TestFaultWithKnownTypeRequest inValue = new NetHttp_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((NetHttp_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            NetHttp_NS.TestFaultWithKnownTypeResponse retVal = await ((NetHttp_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2446,11 +2450,11 @@ namespace NetHttp_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             NetHttp_NS.ThrowInvalidOperationExceptionRequest inValue = new NetHttp_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((NetHttp_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            NetHttp_NS.ThrowInvalidOperationExceptionResponse retVal = await ((NetHttp_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2459,11 +2463,12 @@ namespace NetHttp_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(NetHttp_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<NetHttp_NS.CompositeType> GetDataUsingDataContractAsync(NetHttp_NS.CompositeType composite)
         {
             NetHttp_NS.GetDataUsingDataContractRequest inValue = new NetHttp_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((NetHttp_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            NetHttp_NS.GetDataUsingDataContractResponse retVal = await ((NetHttp_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2472,10 +2477,11 @@ namespace NetHttp_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<NetHttp_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             NetHttp_NS.ValidateMessagePropertyHeadersRequest inValue = new NetHttp_NS.ValidateMessagePropertyHeadersRequest();
-            return ((NetHttp_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            NetHttp_NS.ValidateMessagePropertyHeadersResponse retVal = await ((NetHttp_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2484,10 +2490,11 @@ namespace NetHttp_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<NetHttp_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             NetHttp_NS.UserGetAuthTokenRequest inValue = new NetHttp_NS.UserGetAuthTokenRequest();
-            return ((NetHttp_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            NetHttp_NS.UserGetAuthTokenResponse retVal = await ((NetHttp_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<NetHttp_NS.ReplyBankingData> MessageContractRequestReplyAsync(NetHttp_NS.RequestBankingData request)
@@ -2516,10 +2523,11 @@ namespace NetHttp_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<NetHttp_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             NetHttp_NS.EchoHttpRequestMessagePropertyRequest inValue = new NetHttp_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((NetHttp_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            NetHttp_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((NetHttp_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2528,10 +2536,11 @@ namespace NetHttp_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             NetHttp_NS.GetRestartServiceEndpointRequest inValue = new NetHttp_NS.GetRestartServiceEndpointRequest();
-            return ((NetHttp_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            NetHttp_NS.GetRestartServiceEndpointResponse retVal = await ((NetHttp_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2560,13 +2569,14 @@ namespace NetHttp_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             NetHttp_NS.LoginRequest inValue = new NetHttp_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((NetHttp_NS.IWcfService)(this)).LoginAsync(inValue);
+            NetHttp_NS.LoginResponse retVal = await ((NetHttp_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2580,11 +2590,12 @@ namespace NetHttp_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             NetHttp_NS.GetStreamFromStringRequest inValue = new NetHttp_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((NetHttp_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            NetHttp_NS.GetStreamFromStringResponse retVal = await ((NetHttp_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2593,11 +2604,12 @@ namespace NetHttp_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             NetHttp_NS.GetStringFromStreamRequest inValue = new NetHttp_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((NetHttp_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            NetHttp_NS.GetStringFromStreamResponse retVal = await ((NetHttp_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2611,11 +2623,12 @@ namespace NetHttp_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             NetHttp_NS.EchoMessageParameterRequest inValue = new NetHttp_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((NetHttp_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            NetHttp_NS.EchoMessageParameterResponse retVal = await ((NetHttp_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2624,11 +2637,12 @@ namespace NetHttp_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             NetHttp_NS.EchoItemsRequest inValue = new NetHttp_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((NetHttp_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            NetHttp_NS.EchoItemsResponse retVal = await ((NetHttp_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2652,11 +2666,11 @@ namespace NetHttp_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             NetHttp_NS.ReturnContentTypeRequest inValue = new NetHttp_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((NetHttp_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            NetHttp_NS.ReturnContentTypeResponse retVal = await ((NetHttp_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2696,10 +2710,11 @@ namespace NetHttp_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttp_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<NetHttp_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             NetHttp_NS.GetRequestHttpHeadersRequest inValue = new NetHttp_NS.GetRequestHttpHeadersRequest();
-            return ((NetHttp_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            NetHttp_NS.GetRequestHttpHeadersResponse retVal = await ((NetHttp_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpWebSockets/Reference.cs
@@ -2362,12 +2362,13 @@ namespace NetHttpWebSockets_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             NetHttpWebSockets_NS.EchoWithTimeoutRequest inValue = new NetHttpWebSockets_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            NetHttpWebSockets_NS.EchoWithTimeoutResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2381,11 +2382,12 @@ namespace NetHttpWebSockets_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             NetHttpWebSockets_NS.EchoRequest inValue = new NetHttpWebSockets_NS.EchoRequest();
             inValue.message = message;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).EchoAsync(inValue);
+            NetHttpWebSockets_NS.EchoResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2394,11 +2396,12 @@ namespace NetHttpWebSockets_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.EchoComplexResponse> EchoComplexAsync(NetHttpWebSockets_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<NetHttpWebSockets_NS.ComplexCompositeType> EchoComplexAsync(NetHttpWebSockets_NS.ComplexCompositeType message)
         {
             NetHttpWebSockets_NS.EchoComplexRequest inValue = new NetHttpWebSockets_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            NetHttpWebSockets_NS.EchoComplexResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2407,11 +2410,11 @@ namespace NetHttpWebSockets_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             NetHttpWebSockets_NS.TestFaultRequest inValue = new NetHttpWebSockets_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            NetHttpWebSockets_NS.TestFaultResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2425,12 +2428,12 @@ namespace NetHttpWebSockets_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             NetHttpWebSockets_NS.TestFaultsRequest inValue = new NetHttpWebSockets_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            NetHttpWebSockets_NS.TestFaultsResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2439,12 +2442,13 @@ namespace NetHttpWebSockets_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             NetHttpWebSockets_NS.TestFaultWithKnownTypeRequest inValue = new NetHttpWebSockets_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            NetHttpWebSockets_NS.TestFaultWithKnownTypeResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2453,11 +2457,11 @@ namespace NetHttpWebSockets_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             NetHttpWebSockets_NS.ThrowInvalidOperationExceptionRequest inValue = new NetHttpWebSockets_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            NetHttpWebSockets_NS.ThrowInvalidOperationExceptionResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2466,11 +2470,12 @@ namespace NetHttpWebSockets_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(NetHttpWebSockets_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<NetHttpWebSockets_NS.CompositeType> GetDataUsingDataContractAsync(NetHttpWebSockets_NS.CompositeType composite)
         {
             NetHttpWebSockets_NS.GetDataUsingDataContractRequest inValue = new NetHttpWebSockets_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            NetHttpWebSockets_NS.GetDataUsingDataContractResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2479,10 +2484,11 @@ namespace NetHttpWebSockets_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<NetHttpWebSockets_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             NetHttpWebSockets_NS.ValidateMessagePropertyHeadersRequest inValue = new NetHttpWebSockets_NS.ValidateMessagePropertyHeadersRequest();
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            NetHttpWebSockets_NS.ValidateMessagePropertyHeadersResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2491,10 +2497,11 @@ namespace NetHttpWebSockets_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<NetHttpWebSockets_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             NetHttpWebSockets_NS.UserGetAuthTokenRequest inValue = new NetHttpWebSockets_NS.UserGetAuthTokenRequest();
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            NetHttpWebSockets_NS.UserGetAuthTokenResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<NetHttpWebSockets_NS.ReplyBankingData> MessageContractRequestReplyAsync(NetHttpWebSockets_NS.RequestBankingData request)
@@ -2523,10 +2530,11 @@ namespace NetHttpWebSockets_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<NetHttpWebSockets_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             NetHttpWebSockets_NS.EchoHttpRequestMessagePropertyRequest inValue = new NetHttpWebSockets_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            NetHttpWebSockets_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2535,10 +2543,11 @@ namespace NetHttpWebSockets_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             NetHttpWebSockets_NS.GetRestartServiceEndpointRequest inValue = new NetHttpWebSockets_NS.GetRestartServiceEndpointRequest();
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            NetHttpWebSockets_NS.GetRestartServiceEndpointResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2567,13 +2576,14 @@ namespace NetHttpWebSockets_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             NetHttpWebSockets_NS.LoginRequest inValue = new NetHttpWebSockets_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).LoginAsync(inValue);
+            NetHttpWebSockets_NS.LoginResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2587,11 +2597,12 @@ namespace NetHttpWebSockets_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             NetHttpWebSockets_NS.GetStreamFromStringRequest inValue = new NetHttpWebSockets_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            NetHttpWebSockets_NS.GetStreamFromStringResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2600,11 +2611,12 @@ namespace NetHttpWebSockets_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             NetHttpWebSockets_NS.GetStringFromStreamRequest inValue = new NetHttpWebSockets_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            NetHttpWebSockets_NS.GetStringFromStreamResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2618,11 +2630,12 @@ namespace NetHttpWebSockets_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             NetHttpWebSockets_NS.EchoMessageParameterRequest inValue = new NetHttpWebSockets_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            NetHttpWebSockets_NS.EchoMessageParameterResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2631,11 +2644,12 @@ namespace NetHttpWebSockets_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             NetHttpWebSockets_NS.EchoItemsRequest inValue = new NetHttpWebSockets_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            NetHttpWebSockets_NS.EchoItemsResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2659,11 +2673,11 @@ namespace NetHttpWebSockets_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             NetHttpWebSockets_NS.ReturnContentTypeRequest inValue = new NetHttpWebSockets_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            NetHttpWebSockets_NS.ReturnContentTypeResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2703,10 +2717,11 @@ namespace NetHttpWebSockets_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpWebSockets_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<NetHttpWebSockets_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             NetHttpWebSockets_NS.GetRequestHttpHeadersRequest inValue = new NetHttpWebSockets_NS.GetRequestHttpHeadersRequest();
-            return ((NetHttpWebSockets_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            NetHttpWebSockets_NS.GetRequestHttpHeadersResponse retVal = await ((NetHttpWebSockets_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttps/Reference.cs
@@ -2355,12 +2355,13 @@ namespace NetHttps_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             NetHttps_NS.EchoWithTimeoutRequest inValue = new NetHttps_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((NetHttps_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            NetHttps_NS.EchoWithTimeoutResponse retVal = await ((NetHttps_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2374,11 +2375,12 @@ namespace NetHttps_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             NetHttps_NS.EchoRequest inValue = new NetHttps_NS.EchoRequest();
             inValue.message = message;
-            return ((NetHttps_NS.IWcfService)(this)).EchoAsync(inValue);
+            NetHttps_NS.EchoResponse retVal = await ((NetHttps_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2387,11 +2389,12 @@ namespace NetHttps_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.EchoComplexResponse> EchoComplexAsync(NetHttps_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<NetHttps_NS.ComplexCompositeType> EchoComplexAsync(NetHttps_NS.ComplexCompositeType message)
         {
             NetHttps_NS.EchoComplexRequest inValue = new NetHttps_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((NetHttps_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            NetHttps_NS.EchoComplexResponse retVal = await ((NetHttps_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2400,11 +2403,11 @@ namespace NetHttps_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             NetHttps_NS.TestFaultRequest inValue = new NetHttps_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((NetHttps_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            NetHttps_NS.TestFaultResponse retVal = await ((NetHttps_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2418,12 +2421,12 @@ namespace NetHttps_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             NetHttps_NS.TestFaultsRequest inValue = new NetHttps_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((NetHttps_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            NetHttps_NS.TestFaultsResponse retVal = await ((NetHttps_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2432,12 +2435,13 @@ namespace NetHttps_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             NetHttps_NS.TestFaultWithKnownTypeRequest inValue = new NetHttps_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((NetHttps_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            NetHttps_NS.TestFaultWithKnownTypeResponse retVal = await ((NetHttps_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2446,11 +2450,11 @@ namespace NetHttps_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             NetHttps_NS.ThrowInvalidOperationExceptionRequest inValue = new NetHttps_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((NetHttps_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            NetHttps_NS.ThrowInvalidOperationExceptionResponse retVal = await ((NetHttps_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2459,11 +2463,12 @@ namespace NetHttps_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(NetHttps_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<NetHttps_NS.CompositeType> GetDataUsingDataContractAsync(NetHttps_NS.CompositeType composite)
         {
             NetHttps_NS.GetDataUsingDataContractRequest inValue = new NetHttps_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((NetHttps_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            NetHttps_NS.GetDataUsingDataContractResponse retVal = await ((NetHttps_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2472,10 +2477,11 @@ namespace NetHttps_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<NetHttps_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             NetHttps_NS.ValidateMessagePropertyHeadersRequest inValue = new NetHttps_NS.ValidateMessagePropertyHeadersRequest();
-            return ((NetHttps_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            NetHttps_NS.ValidateMessagePropertyHeadersResponse retVal = await ((NetHttps_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2484,10 +2490,11 @@ namespace NetHttps_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<NetHttps_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             NetHttps_NS.UserGetAuthTokenRequest inValue = new NetHttps_NS.UserGetAuthTokenRequest();
-            return ((NetHttps_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            NetHttps_NS.UserGetAuthTokenResponse retVal = await ((NetHttps_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<NetHttps_NS.ReplyBankingData> MessageContractRequestReplyAsync(NetHttps_NS.RequestBankingData request)
@@ -2516,10 +2523,11 @@ namespace NetHttps_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<NetHttps_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             NetHttps_NS.EchoHttpRequestMessagePropertyRequest inValue = new NetHttps_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((NetHttps_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            NetHttps_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((NetHttps_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2528,10 +2536,11 @@ namespace NetHttps_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             NetHttps_NS.GetRestartServiceEndpointRequest inValue = new NetHttps_NS.GetRestartServiceEndpointRequest();
-            return ((NetHttps_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            NetHttps_NS.GetRestartServiceEndpointResponse retVal = await ((NetHttps_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2560,13 +2569,14 @@ namespace NetHttps_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             NetHttps_NS.LoginRequest inValue = new NetHttps_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((NetHttps_NS.IWcfService)(this)).LoginAsync(inValue);
+            NetHttps_NS.LoginResponse retVal = await ((NetHttps_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2580,11 +2590,12 @@ namespace NetHttps_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             NetHttps_NS.GetStreamFromStringRequest inValue = new NetHttps_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((NetHttps_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            NetHttps_NS.GetStreamFromStringResponse retVal = await ((NetHttps_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2593,11 +2604,12 @@ namespace NetHttps_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             NetHttps_NS.GetStringFromStreamRequest inValue = new NetHttps_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((NetHttps_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            NetHttps_NS.GetStringFromStreamResponse retVal = await ((NetHttps_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2611,11 +2623,12 @@ namespace NetHttps_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             NetHttps_NS.EchoMessageParameterRequest inValue = new NetHttps_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((NetHttps_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            NetHttps_NS.EchoMessageParameterResponse retVal = await ((NetHttps_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2624,11 +2637,12 @@ namespace NetHttps_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             NetHttps_NS.EchoItemsRequest inValue = new NetHttps_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((NetHttps_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            NetHttps_NS.EchoItemsResponse retVal = await ((NetHttps_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2652,11 +2666,11 @@ namespace NetHttps_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             NetHttps_NS.ReturnContentTypeRequest inValue = new NetHttps_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((NetHttps_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            NetHttps_NS.ReturnContentTypeResponse retVal = await ((NetHttps_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2696,10 +2710,11 @@ namespace NetHttps_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttps_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<NetHttps_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             NetHttps_NS.GetRequestHttpHeadersRequest inValue = new NetHttps_NS.GetRequestHttpHeadersRequest();
-            return ((NetHttps_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            NetHttps_NS.GetRequestHttpHeadersResponse retVal = await ((NetHttps_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNetHttpSvcs/NetHttpsWebSockets/Reference.cs
@@ -2362,12 +2362,13 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             NetHttpsWebSockets_NS.EchoWithTimeoutRequest inValue = new NetHttpsWebSockets_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            NetHttpsWebSockets_NS.EchoWithTimeoutResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2381,11 +2382,12 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             NetHttpsWebSockets_NS.EchoRequest inValue = new NetHttpsWebSockets_NS.EchoRequest();
             inValue.message = message;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoAsync(inValue);
+            NetHttpsWebSockets_NS.EchoResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2394,11 +2396,12 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.EchoComplexResponse> EchoComplexAsync(NetHttpsWebSockets_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<NetHttpsWebSockets_NS.ComplexCompositeType> EchoComplexAsync(NetHttpsWebSockets_NS.ComplexCompositeType message)
         {
             NetHttpsWebSockets_NS.EchoComplexRequest inValue = new NetHttpsWebSockets_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            NetHttpsWebSockets_NS.EchoComplexResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2407,11 +2410,11 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             NetHttpsWebSockets_NS.TestFaultRequest inValue = new NetHttpsWebSockets_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            NetHttpsWebSockets_NS.TestFaultResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2425,12 +2428,12 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             NetHttpsWebSockets_NS.TestFaultsRequest inValue = new NetHttpsWebSockets_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            NetHttpsWebSockets_NS.TestFaultsResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2439,12 +2442,13 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             NetHttpsWebSockets_NS.TestFaultWithKnownTypeRequest inValue = new NetHttpsWebSockets_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            NetHttpsWebSockets_NS.TestFaultWithKnownTypeResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2453,11 +2457,11 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             NetHttpsWebSockets_NS.ThrowInvalidOperationExceptionRequest inValue = new NetHttpsWebSockets_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            NetHttpsWebSockets_NS.ThrowInvalidOperationExceptionResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2466,11 +2470,12 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(NetHttpsWebSockets_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<NetHttpsWebSockets_NS.CompositeType> GetDataUsingDataContractAsync(NetHttpsWebSockets_NS.CompositeType composite)
         {
             NetHttpsWebSockets_NS.GetDataUsingDataContractRequest inValue = new NetHttpsWebSockets_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            NetHttpsWebSockets_NS.GetDataUsingDataContractResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2479,10 +2484,11 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<NetHttpsWebSockets_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             NetHttpsWebSockets_NS.ValidateMessagePropertyHeadersRequest inValue = new NetHttpsWebSockets_NS.ValidateMessagePropertyHeadersRequest();
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            NetHttpsWebSockets_NS.ValidateMessagePropertyHeadersResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2491,10 +2497,11 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<NetHttpsWebSockets_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             NetHttpsWebSockets_NS.UserGetAuthTokenRequest inValue = new NetHttpsWebSockets_NS.UserGetAuthTokenRequest();
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            NetHttpsWebSockets_NS.UserGetAuthTokenResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.ReplyBankingData> MessageContractRequestReplyAsync(NetHttpsWebSockets_NS.RequestBankingData request)
@@ -2523,10 +2530,11 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<NetHttpsWebSockets_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             NetHttpsWebSockets_NS.EchoHttpRequestMessagePropertyRequest inValue = new NetHttpsWebSockets_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            NetHttpsWebSockets_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2535,10 +2543,11 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             NetHttpsWebSockets_NS.GetRestartServiceEndpointRequest inValue = new NetHttpsWebSockets_NS.GetRestartServiceEndpointRequest();
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            NetHttpsWebSockets_NS.GetRestartServiceEndpointResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2567,13 +2576,14 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             NetHttpsWebSockets_NS.LoginRequest inValue = new NetHttpsWebSockets_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).LoginAsync(inValue);
+            NetHttpsWebSockets_NS.LoginResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2587,11 +2597,12 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             NetHttpsWebSockets_NS.GetStreamFromStringRequest inValue = new NetHttpsWebSockets_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            NetHttpsWebSockets_NS.GetStreamFromStringResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2600,11 +2611,12 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             NetHttpsWebSockets_NS.GetStringFromStreamRequest inValue = new NetHttpsWebSockets_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            NetHttpsWebSockets_NS.GetStringFromStreamResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2618,11 +2630,12 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             NetHttpsWebSockets_NS.EchoMessageParameterRequest inValue = new NetHttpsWebSockets_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            NetHttpsWebSockets_NS.EchoMessageParameterResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2631,11 +2644,12 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             NetHttpsWebSockets_NS.EchoItemsRequest inValue = new NetHttpsWebSockets_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            NetHttpsWebSockets_NS.EchoItemsResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2659,11 +2673,11 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             NetHttpsWebSockets_NS.ReturnContentTypeRequest inValue = new NetHttpsWebSockets_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            NetHttpsWebSockets_NS.ReturnContentTypeResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2703,10 +2717,11 @@ namespace NetHttpsWebSockets_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<NetHttpsWebSockets_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<NetHttpsWebSockets_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             NetHttpsWebSockets_NS.GetRequestHttpHeadersRequest inValue = new NetHttpsWebSockets_NS.GetRequestHttpHeadersRequest();
-            return ((NetHttpsWebSockets_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            NetHttpsWebSockets_NS.GetRequestHttpHeadersResponse retVal = await ((NetHttpsWebSockets_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WcfRuntimeNettcpTransSecMessCredsUserName/TcpTransSecMessCredsUserName/Reference.cs
@@ -2362,12 +2362,13 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             TcpTransSecMessCredsUserName_NS.EchoWithTimeoutRequest inValue = new TcpTransSecMessCredsUserName_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.EchoWithTimeoutResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2381,11 +2382,12 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             TcpTransSecMessCredsUserName_NS.EchoRequest inValue = new TcpTransSecMessCredsUserName_NS.EchoRequest();
             inValue.message = message;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.EchoResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2394,11 +2396,12 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.EchoComplexResponse> EchoComplexAsync(TcpTransSecMessCredsUserName_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.ComplexCompositeType> EchoComplexAsync(TcpTransSecMessCredsUserName_NS.ComplexCompositeType message)
         {
             TcpTransSecMessCredsUserName_NS.EchoComplexRequest inValue = new TcpTransSecMessCredsUserName_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.EchoComplexResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2407,11 +2410,11 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             TcpTransSecMessCredsUserName_NS.TestFaultRequest inValue = new TcpTransSecMessCredsUserName_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.TestFaultResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2425,12 +2428,12 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             TcpTransSecMessCredsUserName_NS.TestFaultsRequest inValue = new TcpTransSecMessCredsUserName_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.TestFaultsResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2439,12 +2442,13 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             TcpTransSecMessCredsUserName_NS.TestFaultWithKnownTypeRequest inValue = new TcpTransSecMessCredsUserName_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.TestFaultWithKnownTypeResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2453,11 +2457,11 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             TcpTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionRequest inValue = new TcpTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2466,11 +2470,12 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(TcpTransSecMessCredsUserName_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.CompositeType> GetDataUsingDataContractAsync(TcpTransSecMessCredsUserName_NS.CompositeType composite)
         {
             TcpTransSecMessCredsUserName_NS.GetDataUsingDataContractRequest inValue = new TcpTransSecMessCredsUserName_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.GetDataUsingDataContractResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2479,10 +2484,11 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             TcpTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersRequest inValue = new TcpTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersRequest();
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2491,10 +2497,11 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             TcpTransSecMessCredsUserName_NS.UserGetAuthTokenRequest inValue = new TcpTransSecMessCredsUserName_NS.UserGetAuthTokenRequest();
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.UserGetAuthTokenResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.ReplyBankingData> MessageContractRequestReplyAsync(TcpTransSecMessCredsUserName_NS.RequestBankingData request)
@@ -2523,10 +2530,11 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             TcpTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyRequest inValue = new TcpTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2535,10 +2543,11 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             TcpTransSecMessCredsUserName_NS.GetRestartServiceEndpointRequest inValue = new TcpTransSecMessCredsUserName_NS.GetRestartServiceEndpointRequest();
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.GetRestartServiceEndpointResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2567,13 +2576,14 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             TcpTransSecMessCredsUserName_NS.LoginRequest inValue = new TcpTransSecMessCredsUserName_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).LoginAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.LoginResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2587,11 +2597,12 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             TcpTransSecMessCredsUserName_NS.GetStreamFromStringRequest inValue = new TcpTransSecMessCredsUserName_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.GetStreamFromStringResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2600,11 +2611,12 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             TcpTransSecMessCredsUserName_NS.GetStringFromStreamRequest inValue = new TcpTransSecMessCredsUserName_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.GetStringFromStreamResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2618,11 +2630,12 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             TcpTransSecMessCredsUserName_NS.EchoMessageParameterRequest inValue = new TcpTransSecMessCredsUserName_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.EchoMessageParameterResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2631,11 +2644,12 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             TcpTransSecMessCredsUserName_NS.EchoItemsRequest inValue = new TcpTransSecMessCredsUserName_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.EchoItemsResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2659,11 +2673,11 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             TcpTransSecMessCredsUserName_NS.ReturnContentTypeRequest inValue = new TcpTransSecMessCredsUserName_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.ReturnContentTypeResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2703,10 +2717,11 @@ namespace TcpTransSecMessCredsUserName_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<TcpTransSecMessCredsUserName_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest inValue = new TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest();
-            return ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            TcpTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse retVal = await ((TcpTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
+++ b/src/dotnet-svcutil/lib/tests/Baselines/WsHttpBindingAndws2007HttpBindingTransSecMessCredsUserName/HttpsTransSecMessCredsUserName/Reference.cs
@@ -2355,12 +2355,13 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoWithTimeoutAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.EchoWithTimeoutResponse> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
+        public async System.Threading.Tasks.Task<string> EchoWithTimeoutAsync(string message, string serviceOperationTimeout)
         {
             HttpsTransSecMessCredsUserName_NS.EchoWithTimeoutRequest inValue = new HttpsTransSecMessCredsUserName_NS.EchoWithTimeoutRequest();
             inValue.message = message;
             inValue.serviceOperationTimeout = serviceOperationTimeout;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.EchoWithTimeoutResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoWithTimeoutAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoWithTimeoutResult;
         }
         
         public System.Threading.Tasks.Task<System.ServiceModel.Channels.Message> MessageRequestReplyAsync(System.ServiceModel.Channels.Message request)
@@ -2374,11 +2375,12 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.EchoResponse> EchoAsync(string message)
+        public async System.Threading.Tasks.Task<string> EchoAsync(string message)
         {
             HttpsTransSecMessCredsUserName_NS.EchoRequest inValue = new HttpsTransSecMessCredsUserName_NS.EchoRequest();
             inValue.message = message;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.EchoResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2387,11 +2389,12 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoComplexAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.EchoComplexResponse> EchoComplexAsync(HttpsTransSecMessCredsUserName_NS.ComplexCompositeType message)
+        public async System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.ComplexCompositeType> EchoComplexAsync(HttpsTransSecMessCredsUserName_NS.ComplexCompositeType message)
         {
             HttpsTransSecMessCredsUserName_NS.EchoComplexRequest inValue = new HttpsTransSecMessCredsUserName_NS.EchoComplexRequest();
             inValue.message = message;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoComplexAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.EchoComplexResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoComplexAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoComplexResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2400,11 +2403,11 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.TestFaultAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.TestFaultResponse> TestFaultAsync(string faultMsg)
+        public async System.Threading.Tasks.Task TestFaultAsync(string faultMsg)
         {
             HttpsTransSecMessCredsUserName_NS.TestFaultRequest inValue = new HttpsTransSecMessCredsUserName_NS.TestFaultRequest();
             inValue.faultMsg = faultMsg;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.TestFaultResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultAsync(inValue).ConfigureAwait(false);
         }
         
         public System.Threading.Tasks.Task TestFaultIntAsync(int faultCode)
@@ -2418,12 +2421,12 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.TestFaultsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.TestFaultsResponse> TestFaultsAsync(string faultMsg, bool throwFaultDetail)
+        public async System.Threading.Tasks.Task TestFaultsAsync(string faultMsg, bool throwFaultDetail)
         {
             HttpsTransSecMessCredsUserName_NS.TestFaultsRequest inValue = new HttpsTransSecMessCredsUserName_NS.TestFaultsRequest();
             inValue.faultMsg = faultMsg;
             inValue.throwFaultDetail = throwFaultDetail;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultsAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.TestFaultsResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultsAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2432,12 +2435,13 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.TestFaultWithKnownTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.TestFaultWithKnownTypeResponse> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
+        public async System.Threading.Tasks.Task<object[]> TestFaultWithKnownTypeAsync(string faultMsg, object[] objects)
         {
             HttpsTransSecMessCredsUserName_NS.TestFaultWithKnownTypeRequest inValue = new HttpsTransSecMessCredsUserName_NS.TestFaultWithKnownTypeRequest();
             inValue.faultMsg = faultMsg;
             inValue.objects = objects;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.TestFaultWithKnownTypeResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).TestFaultWithKnownTypeAsync(inValue).ConfigureAwait(false);
+            return retVal.TestFaultWithKnownTypeResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2446,11 +2450,11 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.ThrowInvalidOperationExceptionAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionResponse> ThrowInvalidOperationExceptionAsync(string message)
+        public async System.Threading.Tasks.Task ThrowInvalidOperationExceptionAsync(string message)
         {
             HttpsTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionRequest inValue = new HttpsTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionRequest();
             inValue.message = message;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.ThrowInvalidOperationExceptionResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ThrowInvalidOperationExceptionAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2459,11 +2463,12 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.GetDataUsingDataContractAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.GetDataUsingDataContractResponse> GetDataUsingDataContractAsync(HttpsTransSecMessCredsUserName_NS.CompositeType composite)
+        public async System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.CompositeType> GetDataUsingDataContractAsync(HttpsTransSecMessCredsUserName_NS.CompositeType composite)
         {
             HttpsTransSecMessCredsUserName_NS.GetDataUsingDataContractRequest inValue = new HttpsTransSecMessCredsUserName_NS.GetDataUsingDataContractRequest();
             inValue.composite = composite;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.GetDataUsingDataContractResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetDataUsingDataContractAsync(inValue).ConfigureAwait(false);
+            return retVal.GetDataUsingDataContractResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2472,10 +2477,11 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.ValidateMessagePropertyHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersResponse> ValidateMessagePropertyHeadersAsync()
+        public async System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> ValidateMessagePropertyHeadersAsync()
         {
             HttpsTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersRequest inValue = new HttpsTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersRequest();
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.ValidateMessagePropertyHeadersResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ValidateMessagePropertyHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.ValidateMessagePropertyHeadersResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2484,10 +2490,11 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.UserGetAuthTokenAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.UserGetAuthTokenResponse> UserGetAuthTokenAsync()
+        public async System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.ResultOfstring> UserGetAuthTokenAsync()
         {
             HttpsTransSecMessCredsUserName_NS.UserGetAuthTokenRequest inValue = new HttpsTransSecMessCredsUserName_NS.UserGetAuthTokenRequest();
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.UserGetAuthTokenResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).UserGetAuthTokenAsync(inValue).ConfigureAwait(false);
+            return retVal.UserGetAuthTokenResult;
         }
         
         public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.ReplyBankingData> MessageContractRequestReplyAsync(HttpsTransSecMessCredsUserName_NS.RequestBankingData request)
@@ -2516,10 +2523,11 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoHttpRequestMessagePropertyAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyResponse> EchoHttpRequestMessagePropertyAsync()
+        public async System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.TestHttpRequestMessageProperty> EchoHttpRequestMessagePropertyAsync()
         {
             HttpsTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyRequest inValue = new HttpsTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyRequest();
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.EchoHttpRequestMessagePropertyResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoHttpRequestMessagePropertyAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoHttpRequestMessagePropertyResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2528,10 +2536,11 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.GetRestartServiceEndpointAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.GetRestartServiceEndpointResponse> GetRestartServiceEndpointAsync()
+        public async System.Threading.Tasks.Task<string> GetRestartServiceEndpointAsync()
         {
             HttpsTransSecMessCredsUserName_NS.GetRestartServiceEndpointRequest inValue = new HttpsTransSecMessCredsUserName_NS.GetRestartServiceEndpointRequest();
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.GetRestartServiceEndpointResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRestartServiceEndpointAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRestartServiceEndpointResult;
         }
         
         public System.Threading.Tasks.Task<string> EchoXmlSerializerFormatAsync(string message)
@@ -2560,13 +2569,14 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.LoginAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.LoginResponse> LoginAsync(string clientId, string user, string pwd)
+        public async System.Threading.Tasks.Task<string> LoginAsync(string clientId, string user, string pwd)
         {
             HttpsTransSecMessCredsUserName_NS.LoginRequest inValue = new HttpsTransSecMessCredsUserName_NS.LoginRequest();
             inValue.clientId = clientId;
             inValue.user = user;
             inValue.pwd = pwd;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).LoginAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.LoginResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).LoginAsync(inValue).ConfigureAwait(false);
+            return retVal.@return;
         }
         
         public System.Threading.Tasks.Task<string> GetIncomingMessageHeadersMessageAsync(string customHeaderName, string customHeaderNS)
@@ -2580,11 +2590,12 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.GetStreamFromStringAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.GetStreamFromStringResponse> GetStreamFromStringAsync(string data)
+        public async System.Threading.Tasks.Task<System.IO.Stream> GetStreamFromStringAsync(string data)
         {
             HttpsTransSecMessCredsUserName_NS.GetStreamFromStringRequest inValue = new HttpsTransSecMessCredsUserName_NS.GetStreamFromStringRequest();
             inValue.data = data;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.GetStreamFromStringResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetStreamFromStringAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStreamFromStringResult;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2593,11 +2604,12 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.GetStringFromStreamAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.GetStringFromStreamResponse> GetStringFromStreamAsync(System.IO.Stream stream)
+        public async System.Threading.Tasks.Task<string> GetStringFromStreamAsync(System.IO.Stream stream)
         {
             HttpsTransSecMessCredsUserName_NS.GetStringFromStreamRequest inValue = new HttpsTransSecMessCredsUserName_NS.GetStringFromStreamRequest();
             inValue.stream = stream;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.GetStringFromStreamResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetStringFromStreamAsync(inValue).ConfigureAwait(false);
+            return retVal.GetStringFromStreamResult;
         }
         
         public System.Threading.Tasks.Task<System.IO.Stream> EchoStreamAsync(System.IO.Stream stream)
@@ -2611,11 +2623,12 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoMessageParameterAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.EchoMessageParameterResponse> EchoMessageParameterAsync(string name)
+        public async System.Threading.Tasks.Task<string> EchoMessageParameterAsync(string name)
         {
             HttpsTransSecMessCredsUserName_NS.EchoMessageParameterRequest inValue = new HttpsTransSecMessCredsUserName_NS.EchoMessageParameterRequest();
             inValue.name = name;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.EchoMessageParameterResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoMessageParameterAsync(inValue).ConfigureAwait(false);
+            return retVal.result;
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2624,11 +2637,12 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.EchoItemsAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.EchoItemsResponse> EchoItemsAsync(object[] objects)
+        public async System.Threading.Tasks.Task<object[]> EchoItemsAsync(object[] objects)
         {
             HttpsTransSecMessCredsUserName_NS.EchoItemsRequest inValue = new HttpsTransSecMessCredsUserName_NS.EchoItemsRequest();
             inValue.objects = objects;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoItemsAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.EchoItemsResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).EchoItemsAsync(inValue).ConfigureAwait(false);
+            return retVal.EchoItemsResult;
         }
         
         public System.Threading.Tasks.Task<object[]> EchoItems_XmlAsync(object[] objects)
@@ -2652,11 +2666,11 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.ReturnContentTypeAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.ReturnContentTypeResponse> ReturnContentTypeAsync(string contentType)
+        public async System.Threading.Tasks.Task ReturnContentTypeAsync(string contentType)
         {
             HttpsTransSecMessCredsUserName_NS.ReturnContentTypeRequest inValue = new HttpsTransSecMessCredsUserName_NS.ReturnContentTypeRequest();
             inValue.contentType = contentType;
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.ReturnContentTypeResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).ReturnContentTypeAsync(inValue).ConfigureAwait(false);
         }
         
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2696,10 +2710,11 @@ namespace HttpsTransSecMessCredsUserName_NS
             return base.Channel.GetRequestHttpHeadersAsync(request);
         }
         
-        public System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse> GetRequestHttpHeadersAsync()
+        public async System.Threading.Tasks.Task<HttpsTransSecMessCredsUserName_NS.ArrayOfKeyValueOfstringstringKeyValueOfstringstring[]> GetRequestHttpHeadersAsync()
         {
             HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest inValue = new HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersRequest();
-            return ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue);
+            HttpsTransSecMessCredsUserName_NS.GetRequestHttpHeadersResponse retVal = await ((HttpsTransSecMessCredsUserName_NS.IWcfService)(this)).GetRequestHttpHeadersAsync(inValue).ConfigureAwait(false);
+            return retVal.GetRequestHttpHeadersResult;
         }
         
         public System.Threading.Tasks.Task EchoReturnTaskAsync()

--- a/src/dotnet-svcutil/lib/tests/src/AsyncMessageContractTests.cs
+++ b/src/dotnet-svcutil/lib/tests/src/AsyncMessageContractTests.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.ServiceModel.Description;
+using System.Threading.Tasks;
+using Microsoft.CodeDom;
+using Microsoft.CodeDom.Compiler;
+using Microsoft.CSharp;
+using Microsoft.VisualBasic;
+using Xunit;
+
+namespace SvcutilTest
+{
+    public class AsyncMessageContractTests
+    {
+        [Fact]
+        public void GenerateHelperMethod_UnwrapsTaskMessageContractResponse()
+        {
+            CodeMemberMethod helper = CreateHelperMethod();
+
+            Assert.Equal(typeof(Task<>).FullName, helper.ReturnType.BaseType);
+            Assert.Equal("Test.AccountResponse", Assert.Single(helper.ReturnType.TypeArguments.Cast<CodeTypeReference>()).BaseType);
+            Assert.True((bool)helper.UserData[CodeAwaitExpression.AsyncMethodUserDataKey]);
+
+            CodeVariableDeclarationStatement responseDeclaration = Assert.IsType<CodeVariableDeclarationStatement>(helper.Statements[2]);
+            Assert.Equal("Test.GetAccountResponse", responseDeclaration.Type.BaseType);
+            Assert.IsType<CodeAwaitExpression>(responseDeclaration.InitExpression);
+
+            CodeMethodReturnStatement returnStatement = Assert.IsType<CodeMethodReturnStatement>(helper.Statements[3]);
+            CodeFieldReferenceExpression returnedField = Assert.IsType<CodeFieldReferenceExpression>(returnStatement.Expression);
+            Assert.Equal("SingleResponse", returnedField.FieldName);
+        }
+
+        [Fact]
+        public void GenerateHelperMethod_PreservesTaskMessageContractResponseWithMultipleOutputs()
+        {
+            var codeNamespace = new CodeNamespace("Test");
+            var requestMessage = CreateMessageType("GetAccountRequest", "Request", new CodeTypeReference("Test.AccountRequest"));
+            var responseMessage = CreateMessageType("GetAccountResponse", "Result", new CodeTypeReference(typeof(string)));
+            responseMessage.Members.Add(new CodeMemberField(typeof(string), "Header"));
+            var requestType = ServiceContractGenerator.NamespaceHelper.GetCodeTypeReference(codeNamespace, requestMessage);
+            var responseType = ServiceContractGenerator.NamespaceHelper.GetCodeTypeReference(codeNamespace, responseMessage);
+            var method = new CodeMemberMethod
+            {
+                Name = "GetAccountAsync",
+                ReturnType = new CodeTypeReference(typeof(Task<>).FullName, responseType)
+            };
+            method.Parameters.Add(new CodeParameterDeclarationExpression(requestType, "request"));
+
+            CodeMemberMethod helper = ClientClassGenerator.GenerateHelperMethod(new CodeTypeReference("Test.IAccountService"), method);
+
+            Assert.NotNull(helper);
+            Assert.Equal(typeof(Task<>).FullName, helper.ReturnType.BaseType);
+            Assert.Equal("Test.GetAccountResponse", Assert.Single(helper.ReturnType.TypeArguments.Cast<CodeTypeReference>()).BaseType);
+            Assert.Null(helper.UserData[CodeAwaitExpression.AsyncMethodUserDataKey]);
+            Assert.All(helper.Parameters.Cast<CodeParameterDeclarationExpression>(), parameter => Assert.Equal(FieldDirection.In, parameter.Direction));
+            Assert.IsType<CodeMethodReturnStatement>(helper.Statements[2]);
+        }
+
+        [Fact]
+        public void CSharpCodeProvider_GeneratesAsyncAwaitHelper()
+        {
+            string code = GenerateCode(new CSharpCodeProvider(), CreateHelperMethod());
+
+            Assert.Contains("public async System.Threading.Tasks.Task<Test.AccountResponse> GetAccountAsync", code);
+            Assert.Contains("await ((Test.IAccountService)(this)).GetAccountAsync(inValue).ConfigureAwait(false)", code);
+        }
+
+        [Fact]
+        public void VisualBasicCodeProvider_GeneratesAsyncAwaitHelper()
+        {
+            string code = GenerateCode(new VBCodeProvider(), CreateHelperMethod());
+
+            Assert.Contains("Public Async Function GetAccountAsync", code);
+            Assert.Contains("Await CType(Me,Test.IAccountService).GetAccountAsync(inValue).ConfigureAwait(false)", code);
+        }
+
+        private static CodeMemberMethod CreateHelperMethod()
+        {
+            var codeNamespace = new CodeNamespace("Test");
+            var requestMessage = CreateMessageType("GetAccountRequest", "Request", new CodeTypeReference("Test.AccountRequest"));
+            var responseMessage = CreateMessageType("GetAccountResponse", "SingleResponse", new CodeTypeReference("Test.AccountResponse"));
+            var requestType = ServiceContractGenerator.NamespaceHelper.GetCodeTypeReference(codeNamespace, requestMessage);
+            var responseType = ServiceContractGenerator.NamespaceHelper.GetCodeTypeReference(codeNamespace, responseMessage);
+            var method = new CodeMemberMethod
+            {
+                Name = "GetAccountAsync",
+                ReturnType = new CodeTypeReference(typeof(Task<>).FullName, responseType)
+            };
+            method.Parameters.Add(new CodeParameterDeclarationExpression(requestType, "request"));
+
+            CodeMemberMethod helper = ClientClassGenerator.GenerateHelperMethod(new CodeTypeReference("Test.IAccountService"), method);
+
+            Assert.NotNull(helper);
+            return helper;
+        }
+
+        private static string GenerateCode(CodeDomProvider provider, CodeMemberMethod helper)
+        {
+            var compileUnit = new CodeCompileUnit();
+            var codeNamespace = new CodeNamespace("Test");
+            var clientType = new CodeTypeDeclaration("AccountClient");
+            clientType.Members.Add(helper);
+            codeNamespace.Types.Add(clientType);
+            compileUnit.Namespaces.Add(codeNamespace);
+
+            using (provider)
+            using (var writer = new StringWriter())
+            {
+                provider.GenerateCodeFromCompileUnit(compileUnit, writer, new CodeGeneratorOptions());
+                return writer.ToString();
+            }
+        }
+
+        private static CodeTypeDeclaration CreateMessageType(string typeName, string fieldName, CodeTypeReference fieldType)
+        {
+            var messageType = new CodeTypeDeclaration(typeName);
+            messageType.Members.Add(new CodeMemberField(fieldType, fieldName));
+            return messageType;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4171.

## Summary

- unwrap safe single-result message contract responses in task-based convenience methods
- add CodeDOM support for emitting C# `async`/`await` and VB `Async`/`Await`
- preserve response wrappers when flattening would require `ref` or `out` parameters
- add focused regression tests and update generated-code baselines

## Testing

- `dotnet-svcutil-lib.Tests` passed
- compiled all 16 changed generated `Reference.cs` baselines successfully
- verified the issue repro generates `Task<AccountResponse>` and returns the unwrapped response member