### PR TITLE
Fix remaining svcutil ClientCredentialType typo

### DIFF
--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/SRServiceModel.resx
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/SRServiceModel.resx
@@ -1249,7 +1249,7 @@
     <value>Extended protection is not supported on this platform.  Please install the appropriate patch or change the ExtendedProtectionPolicy on the Binding or BindingElement to a value with a PolicyEnforcement value of \"Never\" or \"WhenSupported\".</value>
   </data>
   <data name="HttpClientCredentialTypeInvalid" xml:space="preserve">
-    <value>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</value>
+    <value>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</value>
   </data>
   <data name="TransportDoesNotSupportCompression" xml:space="preserve">
     <value>The transport configured on this binding does not appear to support the CompressionFormat specified ({0}) on the message encoder.  To resolve this issue, set the CompressionFormat on the {1} to '{2}' or use a different transport.</value>

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.cs.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.cs.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">Typ ClientCredentialType {0} může být použit pouze na straně serveru, nikoli na straně klienta. Namísto toho použijte jednu z hodnot None, Basic, Client, Digest, Ntlm, Windows.</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">Typ ClientCredentialType {0} může být použit pouze na straně serveru, nikoli na straně klienta. Namísto toho použijte jednu z hodnot None, Basic, Client, Digest, Ntlm, Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.de.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.de.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">Der ClientCredentialType "{0}" kann nur auf dem Server und nicht auf dem Client verwendet werden. Verwenden Sie stattdessen einen der folgenden Werte: None, Basic, Client, Digest, Ntlm, Windows.</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">Der ClientCredentialType "{0}" kann nur auf dem Server und nicht auf dem Client verwendet werden. Verwenden Sie stattdessen einen der folgenden Werte: None, Basic, Client, Digest, Ntlm, Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.es.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.es.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">Solo se puede usar ClientCredentialType "{0}" en el lado del servidor y no en el del cliente. Use en su lugar los siguientes valores: "None, Basic, Client, Digest, Ntlm, Windows".</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">Solo se puede usar ClientCredentialType "{0}" en el lado del servidor y no en el del cliente. Use en su lugar los siguientes valores: "None, Basic, Client, Digest, Ntlm, Windows".</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.fr.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.fr.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">Le ClientCredentialType '{0}' peut uniquement être utilisé côté serveur, et non côté client. Utilisez une des valeurs suivantes à la place : 'None, Basic, Client, Digest, Ntlm, Windows'.</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">Le ClientCredentialType '{0}' peut uniquement être utilisé côté serveur, et non côté client. Utilisez une des valeurs suivantes à la place : 'None, Basic, Client, Digest, Ntlm, Windows'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.it.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.it.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">L'elemento ClientCredentialType '{0}' può essere usato solo per il server e non per il client. Usare uno dei valori seguenti: 'None, Basic, Client, Digest, Ntlm, Windows'.</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">L'elemento ClientCredentialType '{0}' può essere usato solo per il server e non per il client. Usare uno dei valori seguenti: 'None, Basic, Client, Digest, Ntlm, Windows'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.ja.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.ja.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">ClientCredentialType '{0}' を使用できるのはサーバー側のみで、クライアント側では使用できません。'None'、'Basic'、'Client'、'Digest'、'Ntlm'、'Windows' のいずれかの値を代わりに使用してください。</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">ClientCredentialType '{0}' を使用できるのはサーバー側のみで、クライアント側では使用できません。'None'、'Basic'、'Client'、'Digest'、'Ntlm'、'Windows' のいずれかの値を代わりに使用してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.ko.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.ko.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">ClientCredentialType '{0}'은(는) 클라이언트 쪽이 아닌 서버 쪽에서만 사용할 수 있습니다. 대신 '없음, 기본, 클라이언트, 다이제스트, NTLM, Windows' 값 중 하나를 사용하세요.</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">ClientCredentialType '{0}'은(는) 클라이언트 쪽이 아닌 서버 쪽에서만 사용할 수 있습니다. 대신 '없음, 기본, 클라이언트, 다이제스트, NTLM, Windows' 값 중 하나를 사용하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.pl.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.pl.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">Właściwości ClientCredentialType o wartości „{0}” można użyć tylko po stronie serwera, a nie po stronie klienta. Zamiast niej użyj jednej z następujących wartości: „None, Basic, Client, Digest, Ntlm, Windows”.</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">Właściwości ClientCredentialType o wartości „{0}” można użyć tylko po stronie serwera, a nie po stronie klienta. Zamiast niej użyj jednej z następujących wartości: „None, Basic, Client, Digest, Ntlm, Windows”.</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.pt-BR.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.pt-BR.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">ClientCredentialType '{0}' somente pode ser usado no lado do servidor, não no lado do cliente. Use um dos seguintes valores: 'None, Basic, Client, Digest, Ntlm, Windows'.</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">ClientCredentialType '{0}' somente pode ser usado no lado do servidor, não no lado do cliente. Use um dos seguintes valores: 'None, Basic, Client, Digest, Ntlm, Windows'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.ru.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.ru.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">Тип ClientCredentialType "{0}" может использоваться на стороне сервера, но не клиента. Используйте вместо этого одно из следующих значений: None, Basic, Client, Digest, Ntlm, Windows.</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">Тип ClientCredentialType "{0}" может использоваться на стороне сервера, но не клиента. Используйте вместо этого одно из следующих значений: None, Basic, Client, Digest, Ntlm, Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.tr.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.tr.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">ClientCredentialType '{0}' yalnızca sunucu tarafında kullanılabilir, istemci tarafında kullanılamaz. Lütfen şu değerlerden birini kullanın: 'None, Basic, Client, Digest, Ntlm, Windows'.</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">ClientCredentialType '{0}' yalnızca sunucu tarafında kullanılabilir, istemci tarafında kullanılamaz. Lütfen şu değerlerden birini kullanın: 'None, Basic, Client, Digest, Ntlm, Windows'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.zh-Hans.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.zh-Hans.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">ClientCredentialType“{0}”只能在服务器端使用，而不能在客户端使用。请改用以下值之一: None、Basic、Client、Digest、Ntlm、Windows。</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">ClientCredentialType“{0}”只能在服务器端使用，而不能在客户端使用。请改用以下值之一: None、Basic、Client、Digest、Ntlm、Windows。</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.zh-Hant.xlf
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/xlf/SRServiceModel.zh-Hant.xlf
@@ -1103,8 +1103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HttpClientCredentialTypeInvalid">
-        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</source>
-        <target state="translated">ClientCredentialType '{0}' 只能在伺服器端使用，而非用戶端。請使用下列其中一個值來取代 'None, Basic, Client, Digest, Ntlm, Windows'。</target>
+        <source>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Certificate, Digest, Ntlm, Windows'.</source>
+        <target state="needs-review-translation">ClientCredentialType '{0}' 只能在伺服器端使用，而非用戶端。請使用下列其中一個值來取代 'None, Basic, Client, Digest, Ntlm, Windows'。</target>
         <note />
       </trans-unit>
       <trans-unit id="HttpContentLengthIncorrect">


### PR DESCRIPTION
## Summary

- Fix the remaining `ClientCredentialType` resource typo in the svcutil framework fork by listing `Certificate` instead of `Client`.
- Update the invariant `.resx` resource and all 13 localized `.xlf` source entries.
- Mark localized translations for review without changing their translated text.

This complements dotnet/wcf#5959, which covers the corresponding WCF runtime resource entries.

## Testing

- Targeted `dotnet-svcutil-lib.csproj` build succeeded.
- Changed resource XML files parsed successfully.