### PR TITLE
Allow tests after PR service sync failure

### DIFF
--- a/eng/UpdatePRService.yml
+++ b/eng/UpdatePRService.yml
@@ -103,6 +103,7 @@ steps:
       }
 
     displayName: Sync_PRService_Windows
+    continueOnError: true
     env:
       WCFPRSERVICEURI: ${{ parameters.wcfPRServiceUri }}
       WCFPRSERVICEID: ${{ parameters.wcfPRServiceId }}
@@ -119,6 +120,7 @@ steps:
       "$BUILD_SOURCESDIRECTORY/src/System.Private.ServiceModel/tools/scripts/sync-pr.sh" $WCFPRSERVICEID $OPERATION $WCFPRSERVICEURI $BRANCHNAMEORPRID
 
     displayName: Sync_PRService_Unix
+    continueOnError: true
     env:
       WCFPRSERVICEURI: ${{ parameters.wcfPRServiceUri }}
       WCFPRSERVICEID: ${{ parameters.wcfPRServiceId }}


### PR DESCRIPTION
## Summary

- mark the Windows PR service synchronization step as continue-on-error
- mark the Unix PR service synchronization step as continue-on-error
- preserve synchronization failures as Azure Pipelines warnings while allowing build and test execution to continue

This lets tests use the existing compatible endpoint when synchronization is temporarily unavailable, while keeping the warning visible for diagnosing failures caused by an incompatible endpoint.